### PR TITLE
address architecture findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,12 @@ npm run build
 
 # Lint
 npm run lint
+
+# Unit tests (Vitest)
+npm run test:run
+
+# E2E tests (Playwright)
+npm run test:e2e
 ```
 
 ### Docker
@@ -62,46 +68,86 @@ docker-compose up
 
 ### Backend
 
-- **App factory:** `backend/bcssm_backend/__init__.py` — `create_app()` configures Flask, SQLAlchemy (connection pooling), Redis cache, and registers blueprints. Also defines cache admin routes (`/api/admin/cache/*`).
+- **App factory:** `backend/bcssm_backend/__init__.py` — `create_app()` configures Flask, SQLAlchemy (connection pooling), Redis cache, CORS, and registers 7 route blueprints via `_setup_routes()`.
 - **Config:** `backend/config.py` — three configs: `DevelopmentConfig`, `TestingConfig`, `ProductionConfig`.
-- **Business logic:** `backend/bcssm_backend/utils.py` — all database queries and caching logic live here. Uses `execute_query()` / `execute_readonly_query()` for session management.
-- **Routes:** `backend/bcssm_backend/routes/` — thin handlers that call utils and return JSON. Organized by domain: `routes.py` (login, index), `users.py`, `duties.py`, `sections.py`, `devos_feedback.py`.
+- **Business logic:** `backend/bcssm_backend/utils.py` — all database queries and caching logic. Uses `execute_query()` for writes (db.session) and `execute_readonly_query()` for reads (engine.connect(), no session overhead).
+- **Routes:** `backend/bcssm_backend/routes/` — thin handlers that call utils and return JSON:
+  - `routes.py` — `/`, `/login`, `/duty-teams`, `/users-by-section`, `/user-duty`, `/select-user`, `/get-selected-user`, `/logout`, `/get-users`
+  - `users.py` — `/api/auth/validate`
+  - `duties.py` — `/api/duties/today`, `/api/duties/schedule`
+  - `sections.py` — `/api/users/by-section`, `/api/users/section/<name>`
+  - `devos_feedback.py` — `/api/devos-feedback`, `/api/devos-feedback/edit`
+  - `admin.py` — `/api/admin/cache/clear`, `/api/admin/cache/status`, `/api/admin/cache/info`
+  - `system.py` — `/api/sections`, `/api/health`, React SPA fallback (`/<path>`)
 - **Globals:** `backend/globals.py` — shared `cache` (Redis) and `db` (SQLAlchemy) instances imported by both `__init__.py` and `utils.py`.
+- **Auth helpers:** `backend/bcssm_backend/auth.py` — `get_username_from_request()` extracts username from JSON body, query param, `X-Current-User` header, or session. `get_user_id_from_request()` resolves to DB user ID.
+- **Cache decorator:** `backend/bcssm_backend/cache_utils.py` — `@cached_result(key_fn, ttl, error_ttl)` wraps query functions; supports dynamic keys, SQLAlchemy error fallback with optional error TTL.
+- **Exceptions:** `backend/bcssm_backend/exceptions.py` — `BaseError` → `DatabaseError`, `CacheError`, `ValidationError`, `AuthenticationError`, `NotFoundError`.
 
 ### Caching Strategy (Redis)
 
-| Data | TTL |
-|------|-----|
-| Users list | 15 min |
-| User duty | 10 min |
-| Duty schedule | 2 hours |
-| Sections | 1 hour |
-| Feedback dates | 2 hours |
+| Data | Cache Key Pattern | TTL |
+|------|-------------------|-----|
+| Users list | `users:all:list` | 15 min |
+| User duty | `user:duty:{name}:day{d}:cycle{c}` | 10 min |
+| Today's duties | `duties:today:day{d}:cycle{c}:user{name}` | 30 min |
+| Duty schedule | `duties:schedule:14day:{date}` | 2 hours |
+| All sections | `sections:all:list` | 1 hour |
+| Users by section | `users:section:{section}` | 30 min |
+| Sections with users | `sections:with_users:all_v6` | 30 min |
+| Feedback dates | `feedback:dates:all` | 2 hours |
+| User data | `user:data:{name}` | 30 min |
 
-Each cached function has a corresponding `clear_*_cache()` function.
+Each cached function has a corresponding `clear_*_cache()` function. Duty keys include day-of-week and cycle-week (0 or 1, computed by `get_current_cycle_week()` with `@lru_cache`) to account for bi-weekly rotation.
+
+### Database
+
+- PostgreSQL via SQLAlchemy; connection pool: `pool_size=3`, `max_overflow=7`.
+- Read queries: `execute_readonly_query()` uses `engine.connect()` — no session overhead.
+- Write queries: `execute_query()` uses `db.session.begin()`.
 
 ### Frontend
 
 - **Entry:** `frontend/src/main.tsx` → `App.tsx` defines React Router routes.
 - **API client:** `frontend/src/api.ts` — `apiCall()` wraps fetch and automatically injects the logged-in username into `X-Current-User` header, query params, and POST body. Use `apiGet()` / `apiPost()` wrappers throughout.
-- **Auth:** Username stored in `localStorage` as `currentUser`. Validated via `GET /api/auth/validate` on load.
-- **Vite proxy:** Dev server proxies `/api/`, `/get-`, `/select-`, `/devos-`, `/duty-` to the Flask backend.
+- **Auth:** Username stored in `localStorage` as `currentUser` (also `is_logged_in`, `user_role`, `user_section`, `is_leader`). Validated via `GET /api/auth/validate` on load. Transient network errors do not force logout.
+- **Auth guard:** `frontend/src/hooks/useRequireAuth.ts` — redirect hook; use in every protected page.
+- **Theme:** `ThemeContext.tsx` + `useTheme.ts` — light/dark toggle; wraps app in `ThemeProvider`.
+- **Vite proxy:** Dev server proxies `/api/`, `/get-`, `/select-`, `/devos-`, `/duty-` to the Flask backend on port 8080.
+
+### React Router Pages
+
+| Path | Component | Purpose |
+|------|-----------|---------|
+| `/` | `Home` | Dashboard: duty info, forms for leaders, bank details |
+| `/login` | `Login` | User selection dropdown |
+| `/duties` | `DutiesPage` | Today's duties + 14-day schedule (tabbed) |
+| `/react/devos-feedback` | `DevoFeedback` | View daily feedback by section |
+| `/react/devos-feedback/edit` | `DevoFeedbackEdit` | Edit feedback (leaders only) |
+| `/sections` | `Sections` | Users grouped by section with filtering |
 
 ### Data Flow
 
 1. User logs in → username stored in `localStorage`
 2. All API calls include username (header + query param + body)
 3. Backend routes call utils functions → Redis cache or PostgreSQL
-4. Flask serves the built React `index.html` for all non-API routes (`GET /`)
+4. Flask serves the built React `index.html` for all non-API routes (`GET /<path>`)
 
 ## CI/CD
 
-GitHub Actions (`.github/workflows/python-app.yml`) runs on push/PR to `develop`:
-1. Lint with flake8
-2. Run pytest with coverage
-3. Upload to Codecov (85% coverage target enforced)
+GitHub Actions (`.github/workflows/python-app.yml`) runs on push/PR to `develop` with three parallel jobs:
+
+1. **frontend-unit-tests:** Node 20, `npm run lint`, TypeScript type check, `npm run test:run` (Vitest)
+2. **frontend-e2e-tests:** Node 20, install Playwright, run `npx playwright test`
+3. **build:** Python 3.10, flake8 lint, pytest with coverage, upload to Codecov (85% target enforced via `codecov.yml`)
 
 Active development happens on `develop`; `main` is production.
+
+## Testing
+
+- **Backend unit tests:** `backend/tests/` — 9 files covering routes, utils, auth, cache, and each route domain.
+- **Frontend unit tests:** `frontend/src/__tests__/` — 6 files (Vitest + jsdom + @testing-library/react).
+- **Frontend E2E tests:** Playwright; `npm run test:e2e` (API calls mocked). In E2E mode Vite disables its API proxy.
 
 ## Agent skills
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,141 @@
+# BCSSM
+
+A full-stack web application for managing duty schedules, section rosters, and devotional feedback. Built with Flask (Python) and React (TypeScript), backed by PostgreSQL and Redis.
+
+## Features
+
+- **Duty scheduling** — view today's assigned duties and a 14-day rolling schedule with bi-weekly cycle support
+- **Section management** — browse users grouped by section with search/filter
+- **Devotional feedback** — leaders can submit and edit daily feedback entries by section
+- **Role-based access** — leader vs. member views gated by authentication
+- **Redis caching** — all heavy queries are cached to reduce database load
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Backend | Python 3.13, Flask 3, SQLAlchemy, Gunicorn |
+| Frontend | React 19, TypeScript, Vite, Bootstrap 5 |
+| Database | PostgreSQL (Supabase) |
+| Cache | Redis 7 |
+| Container | Docker + Docker Compose |
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js 20+
+- A running PostgreSQL instance (Supabase or local)
+- Redis 7 (or use Docker Compose, which starts one automatically)
+
+## Environment Variables
+
+Create a `.env` file in the repo root:
+
+```env
+# Flask
+SECRET_KEY=your-secret-key
+
+# PostgreSQL connection (Supabase or local)
+host=your-db-host
+port=5432
+database=your-db-name
+user=your-db-user
+password=your-db-password
+
+# Redis
+REDIS_URL=redis://localhost:6379
+```
+
+## Running Locally
+
+### Option 1 — Docker Compose (recommended)
+
+Builds the full app (frontend + backend) and starts Redis automatically.
+
+```bash
+docker-compose up
+```
+
+The app is available at `http://localhost:8080`.
+
+### Option 2 — Separate dev servers
+
+Run the backend and frontend independently for hot-reload during development.
+
+**Backend** (port 8080):
+
+```bash
+pip install -r backend/requirements.txt
+python backend/bcssm_backend/__init__.py
+```
+
+**Frontend** (port 5173, proxies API calls to the backend):
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Open `http://localhost:5173`. The Vite dev server proxies all `/api/`, `/get-*`, `/select-*`, `/devos-*`, and `/duty-*` requests to the Flask backend on port 8080.
+
+## Testing
+
+**Backend:**
+
+```bash
+pytest backend/tests/
+# With coverage
+pytest backend/tests/ --cov=backend
+```
+
+**Frontend unit tests (Vitest):**
+
+```bash
+cd frontend
+npm run test:run
+```
+
+**Frontend E2E tests (Playwright):**
+
+```bash
+cd frontend
+npx playwright install chromium
+npm run test:e2e
+```
+
+## Project Structure
+
+```
+BCSSM/
+├── backend/
+│   ├── bcssm_backend/
+│   │   ├── __init__.py       # App factory (create_app)
+│   │   ├── routes/           # Thin route handlers
+│   │   ├── utils.py          # All DB queries and cache logic
+│   │   ├── auth.py           # Username/user-ID resolution
+│   │   ├── cache_utils.py    # @cached_result decorator
+│   │   └── exceptions.py     # Domain exception hierarchy
+│   ├── globals.py            # Shared db and cache instances
+│   ├── config.py             # Dev / Test / Prod configs
+│   └── tests/                # pytest test suite
+├── frontend/
+│   ├── src/
+│   │   ├── App.tsx           # React Router routes
+│   │   ├── api.ts            # apiGet / apiPost wrappers
+│   │   └── *.tsx             # Page components
+│   └── src/__tests__/        # Vitest + Playwright tests
+├── docker-compose.yml
+├── Dockerfile
+└── .env                      # Local secrets (not committed)
+```
+
+## CI/CD
+
+GitHub Actions runs on push/PR to `develop`:
+
+- `frontend-unit-tests` — ESLint, TypeScript type-check, Vitest
+- `frontend-e2e-tests` — Playwright (Chromium)
+- `build` — flake8, pytest with coverage, upload to Codecov (85% target)
+
+Production deployment uses Docker on Render; `main` is the production branch.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npm run test:e2e
 
 ## Project Structure
 
-```
+```text
 BCSSM/
 ├── backend/
 │   ├── bcssm_backend/

--- a/backend/bcssm_backend/__init__.py
+++ b/backend/bcssm_backend/__init__.py
@@ -1,13 +1,9 @@
-"""
-Improved app.py with better cache integration
-"""
-
 import logging
 import os
 from pathlib import Path
 
 from dotenv import load_dotenv
-from flask import Flask, send_from_directory, jsonify, request
+from flask import Flask
 from flask_cors import CORS
 
 from backend.config import DevelopmentConfig, ProductionConfig, TestingConfig
@@ -16,19 +12,9 @@ from backend.bcssm_backend.routes.routes import init_main_routes
 from backend.bcssm_backend.routes.users import init_users_routes
 from backend.bcssm_backend.routes.devos_feedback import init_feedback_routes
 from backend.bcssm_backend.routes.duties import init_duties_routes
-from backend.bcssm_backend.routes.sections import (
-    init_users_sections_routes
-)
-
-from redis.exceptions import RedisError
-from sqlalchemy.exc import SQLAlchemyError
-from werkzeug.exceptions import HTTPException
-
-from backend.bcssm_backend.exceptions import BaseError
-from backend.bcssm_backend.utils import (
-    get_all_sections, clear_user_cache, clear_duty_cache,
-    clear_feedback_cache, clear_all_cache
-)
+from backend.bcssm_backend.routes.sections import init_users_sections_routes
+from backend.bcssm_backend.routes.admin import init_admin_routes, register_error_handlers
+from backend.bcssm_backend.routes.system import init_system_routes
 
 
 def _configure_database(app):
@@ -57,83 +43,13 @@ def _configure_database(app):
 
 def _setup_routes(app):
     """Set up all application routes."""
-    # Route initialization
     init_main_routes(app)
     init_users_routes(app)
     init_feedback_routes(app)
     init_duties_routes(app)
     init_users_sections_routes(app)
-
-    # Add cache management routes
-    add_cache_management_routes(app)
-
-    # Sections endpoint
-    @app.route("/api/sections")
-    def api_sections():
-        """Return list of section names in configured display order."""
-        sections = get_all_sections()
-        if isinstance(sections, dict) and "error" in sections:
-            app.logger.error("api_sections failed: %s", sections["error"])
-            return jsonify({"error": "Failed to fetch sections"}), 500
-        return jsonify(sections)
-
-    # Enhanced health check
-    @app.route("/api/health")
-    def health_check():
-        """Enhanced health check including cache status"""
-        try:
-            # Test cache
-            cache.set('health_test', 'ok', timeout=10)
-            cache_status = cache.get('health_test') == 'ok'
-            cache.delete('health_test')
-
-            health_info = {
-                "status": "healthy",
-                "database": "connected",
-                "cache": "healthy" if cache_status else "unhealthy",
-                "environment": os.getenv('FLASK_ENV', 'development'),
-                "redis_url": os.getenv('REDIS_URL', 'redis://localhost:6379')
-            }
-
-            # Overall status based on components
-            if not cache_status:
-                health_info["status"] = "degraded"
-
-            return jsonify(health_info)
-
-        except RedisError as e:
-            app.logger.error("Health check failed: %s", e)
-            return jsonify({
-                "status": "unhealthy",
-                "database": "unknown",
-                "cache": "unhealthy",
-                "error": "Health check failed",
-            }), 500
-
-    # React serving route
-    @app.route("/", defaults={"path": ""})
-    @app.route("/<path:path>")
-    def serve_react(path):
-        """ Serve React index.html for all unknown routes (supports React Router) """
-        app.logger.info("React route fallback triggered for path: %s", path)
-
-        if path.startswith(('api/', 'get-', 'select-', 'devos-', 'duty-')):
-            return app.send_static_file('index.html')
-
-        safe_path = os.path.normpath(path).lstrip("/\\")
-        requested_path = os.path.join(app.static_folder, safe_path)
-        requested_path = os.path.realpath(requested_path)  # Ensure absolute path resolution
-        if not requested_path.startswith(os.path.realpath(app.static_folder)):
-            app.logger.warning("Attempted directory traversal detected: %s", path)
-            return send_from_directory(app.static_folder, "index.html")
-        if os.path.isfile(requested_path):
-            return send_from_directory(
-                app.static_folder,
-                os.path.relpath(requested_path, app.static_folder)
-            )
-
-        app.logger.info("React serving index.html for path: /%s", path)
-        return send_from_directory(app.static_folder, "index.html")
+    init_admin_routes(app)
+    init_system_routes(app)
 
 
 def create_app():
@@ -175,33 +91,8 @@ def create_app():
     # Set up routes
     _setup_routes(app)
 
-    # Global error handlers
-    @app.errorhandler(BaseError)
-    def handle_bcssm_error(e):
-        app.logger.error("Application error: %s", e.message)
-        return jsonify({"error": e.message}), e.status_code
-
-    @app.errorhandler(SQLAlchemyError)
-    def handle_db_error(e):
-        app.logger.error("Unhandled database error: %s", e)
-        return jsonify({"error": "A database error occurred"}), 500
-
-    @app.errorhandler(404)
-    def handle_404(e):
-        if request.path.startswith('/api/'):
-            return jsonify({"error": "Resource not found"}), 404
-        return e
-
-    @app.errorhandler(405)
-    def handle_405(e):
-        return jsonify({"error": "Method not allowed"}), 405
-
-    @app.errorhandler(Exception)
-    def handle_exception(e):
-        if isinstance(e, HTTPException):
-            return e
-        app.logger.error("Unhandled exception: %s", e)
-        return jsonify({"error": "Internal server error"}), 500
+    # Register error handlers
+    register_error_handlers(app)
 
     # Teardown and logging
     @app.teardown_appcontext
@@ -212,106 +103,6 @@ def create_app():
     configure_logging(app)
 
     return app
-
-def add_cache_management_routes(app):
-    """Add cache management endpoints using utils functions"""
-
-    @app.route("/api/admin/cache/clear", methods=['POST'])
-    def clear_cache_endpoint():
-        """Clear cache using utils functions with proper error handling"""
-        try:
-            data = request.get_json() if request.is_json else {}
-            cache_type = data.get('type', 'all')
-
-            if cache_type == 'users':
-                clear_user_cache()
-                message = "Cleared user-related caches"
-            elif cache_type == 'duties':
-                clear_duty_cache()
-                message = "Cleared duty-related caches"
-            elif cache_type == 'feedback':
-                clear_feedback_cache()
-                message = "Cleared feedback caches"
-            elif cache_type == 'all':
-                clear_all_cache()
-                message = "Cleared all caches"
-            else:
-                return jsonify({
-                    "success": False,
-                    "error": "Invalid cache type. Use: users, duties, feedback, or all"
-                }), 400
-
-            return jsonify({
-                "success": True,
-                "message": message,
-                "cache_type": cache_type
-            })
-
-        except RedisError as e:
-            app.logger.error("Cache clearing failed: %s", e)
-            return jsonify({
-                "success": False,
-                "error": "Cache clearing failed"
-            }), 500
-
-    @app.route("/api/admin/cache/status", methods=['GET'])
-    def cache_status():
-        """Get detailed cache status"""
-        try:
-            # Test basic cache operations
-            test_key = 'status_test'
-            cache.set(test_key, 'working', timeout=10)
-            test_result = cache.get(test_key)
-            cache.delete(test_key)
-
-            status_info = {
-                "status": "healthy" if test_result == 'working' else "unhealthy",
-                "redis_url": os.getenv('REDIS_URL', 'redis://localhost:6379'),
-                "default_timeout": 300,
-                "test_result": test_result,
-                "cache_type": "RedisCache",
-                "available_operations": {
-                    "clear_users": "/api/admin/cache/clear (POST with type: users)",
-                    "clear_duties": "/api/admin/cache/clear (POST with type: duties)",
-                    "clear_feedback": "/api/admin/cache/clear (POST with type: feedback)",
-                    "clear_all": "/api/admin/cache/clear (POST with type: all)"
-                }
-            }
-
-            return jsonify(status_info)
-
-        except RedisError as e:
-            app.logger.error("Cache status check failed: %s", e)
-            return jsonify({
-                "status": "unhealthy",
-                "error": "Cache status check failed",
-                "redis_url": os.getenv('REDIS_URL', 'redis://localhost:6379')
-            }), 500
-
-    @app.route("/api/admin/cache/info", methods=['GET'])
-    def cache_info():
-        """Get cache configuration info"""
-        return jsonify({
-            "cache_config": {
-                "type": "RedisCache",
-                "url": os.getenv('REDIS_URL', 'redis://localhost:6379'),
-                "default_timeout": 300
-            },
-            "cached_functions": {
-                "get_all_users": "15 minutes",
-                "get_user_duty": "10 minutes",
-                "get_todays_duties": "30 minutes",
-                "get_duty_schedule": "2 hours",
-                "get_all_sections": "1 hour",
-                "get_users_by_section": "30 minutes",
-                "get_all_feedback_dates": "2 hours"
-            },
-            "management_endpoints": {
-                "status": "GET /api/admin/cache/status",
-                "clear": "POST /api/admin/cache/clear",
-                "info": "GET /api/admin/cache/info"
-            }
-        })
 
 def configure_logging(app=None):
     """Configure logging for the application.

--- a/backend/bcssm_backend/cache_utils.py
+++ b/backend/bcssm_backend/cache_utils.py
@@ -1,3 +1,4 @@
+import copy
 from functools import wraps
 from sqlalchemy.exc import SQLAlchemyError
 import logging
@@ -47,7 +48,7 @@ def cached_result(key_fn, ttl, error_ttl=None, on_error=_RAISE, cache=None):
                 logger.error("Query failed, cache key %s: %s", key, e)
                 if on_error is _RAISE:
                     raise
-                fallback = on_error(e) if callable(on_error) else on_error
+                fallback = on_error(e) if callable(on_error) else copy.copy(on_error)
                 if error_ttl is not None:
                     _cache.set(key, fallback, timeout=error_ttl)
                 return fallback

--- a/backend/bcssm_backend/cache_utils.py
+++ b/backend/bcssm_backend/cache_utils.py
@@ -1,0 +1,56 @@
+from functools import wraps
+from sqlalchemy.exc import SQLAlchemyError
+import logging
+
+logger = logging.getLogger(__name__)
+
+_RAISE = object()
+_ttl_registry = {}
+
+
+def get_ttl_registry():
+    return dict(_ttl_registry)
+
+
+def cached_result(key_fn, ttl, error_ttl=None, on_error=_RAISE, cache=None):
+    """
+    key_fn: str for static keys, or callable(*args, **kwargs) -> str for dynamic keys
+    ttl: success cache TTL (seconds)
+    error_ttl: error cache TTL (seconds); None = don't cache on error
+    on_error: value or callable(exc)->value returned on SQLAlchemyError;
+              default _RAISE re-raises the exception
+    cache: injectable cache instance for testing; defaults to backend.globals.cache
+    """
+    def decorator(func):
+        _ttl_registry[func.__name__] = ttl
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if cache is not None:
+                _cache = cache
+            else:
+                from backend.globals import cache as _global_cache
+                _cache = _global_cache
+
+            key = key_fn(*args, **kwargs) if callable(key_fn) else key_fn
+
+            hit = _cache.get(key)
+            if hit is not None:
+                logger.info("Cache hit: %s", key)
+                return hit
+
+            try:
+                result = func(*args, **kwargs)
+                _cache.set(key, result, timeout=ttl)
+                return result
+            except SQLAlchemyError as e:
+                logger.error("Query failed, cache key %s: %s", key, e)
+                if on_error is _RAISE:
+                    raise
+                fallback = on_error(e) if callable(on_error) else on_error
+                if error_ttl is not None:
+                    _cache.set(key, fallback, timeout=error_ttl)
+                return fallback
+
+        return wrapper
+    return decorator

--- a/backend/bcssm_backend/cache_utils.py
+++ b/backend/bcssm_backend/cache_utils.py
@@ -35,14 +35,21 @@ def cached_result(key_fn, ttl, error_ttl=None, on_error=_RAISE, cache=None):
 
             key = key_fn(*args, **kwargs) if callable(key_fn) else key_fn
 
-            hit = _cache.get(key)
+            try:
+                hit = _cache.get(key)
+            except Exception as e:
+                logger.warning("Cache read failed for %s: %s", key, e)
+                hit = None
             if hit is not None:
                 logger.info("Cache hit: %s", key)
                 return hit
 
             try:
                 result = func(*args, **kwargs)
-                _cache.set(key, result, timeout=ttl)
+                try:
+                    _cache.set(key, result, timeout=ttl)
+                except Exception as e:
+                    logger.warning("Cache write failed for %s: %s", key, e)
                 return result
             except SQLAlchemyError as e:
                 logger.error("Query failed, cache key %s: %s", key, e)
@@ -50,7 +57,10 @@ def cached_result(key_fn, ttl, error_ttl=None, on_error=_RAISE, cache=None):
                     raise
                 fallback = on_error(e) if callable(on_error) else copy.copy(on_error)
                 if error_ttl is not None:
-                    _cache.set(key, fallback, timeout=error_ttl)
+                    try:
+                        _cache.set(key, fallback, timeout=error_ttl)
+                    except Exception as cache_error:
+                        logger.warning("Cache write failed for %s: %s", key, cache_error)
                 return fallback
 
         return wrapper

--- a/backend/bcssm_backend/cache_utils.py
+++ b/backend/bcssm_backend/cache_utils.py
@@ -55,7 +55,7 @@ def cached_result(key_fn, ttl, error_ttl=None, on_error=_RAISE, cache=None):
                 logger.error("Query failed, cache key %s: %s", key, e)
                 if on_error is _RAISE:
                     raise
-                fallback = on_error(e) if callable(on_error) else copy.copy(on_error)
+                fallback = on_error(e) if callable(on_error) else copy.deepcopy(on_error)
                 if error_ttl is not None:
                     try:
                         _cache.set(key, fallback, timeout=error_ttl)

--- a/backend/bcssm_backend/routes/admin.py
+++ b/backend/bcssm_backend/routes/admin.py
@@ -16,6 +16,15 @@ from backend.bcssm_backend.utils import (
 logger = logging.getLogger(__name__)
 
 
+def _fmt_ttl(ttl: int) -> str:
+    if ttl >= 3600:
+        hours = ttl // 3600
+        return f"{hours} hour{'s' if hours != 1 else ''}"
+    if ttl >= 60:
+        return f"{ttl // 60} minutes"
+    return f"{ttl} seconds"
+
+
 def init_admin_routes(app):
     @app.route("/api/admin/cache/clear", methods=['POST'])
     def clear_cache_endpoint():
@@ -79,11 +88,6 @@ def init_admin_routes(app):
 
     @app.route("/api/admin/cache/info", methods=['GET'])
     def cache_info():
-        def _fmt(ttl):
-            if ttl >= 3600:
-                return f"{ttl // 3600} hour{'s' if ttl // 3600 != 1 else ''}"
-            return f"{ttl // 60} minutes"
-
         return jsonify({
             "cache_config": {
                 "type": "RedisCache",
@@ -91,7 +95,7 @@ def init_admin_routes(app):
                 "default_timeout": 300
             },
             "cached_functions": {
-                name: _fmt(ttl) for name, ttl in get_ttl_registry().items()
+                name: _fmt_ttl(ttl) for name, ttl in get_ttl_registry().items()
             },
             "management_endpoints": {
                 "status": "GET /api/admin/cache/status",

--- a/backend/bcssm_backend/routes/admin.py
+++ b/backend/bcssm_backend/routes/admin.py
@@ -6,7 +6,7 @@ from redis.exceptions import RedisError
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import HTTPException
 
-from backend.bcssm_backend.exceptions import BaseError
+from backend.bcssm_backend.exceptions import BaseError, CacheError
 from backend.bcssm_backend.utils import (
     clear_user_cache, clear_duty_cache, clear_feedback_cache, clear_all_cache,
     get_cache_status, get_cache_info, _redact_redis_url,
@@ -50,7 +50,7 @@ def init_admin_routes(app):
     def cache_status():
         try:
             return jsonify(get_cache_status())
-        except RedisError as e:
+        except (RedisError, CacheError) as e:
             app.logger.error("Cache status check failed: %s", e)
             return jsonify({
                 "status": "unhealthy",

--- a/backend/bcssm_backend/routes/admin.py
+++ b/backend/bcssm_backend/routes/admin.py
@@ -1,37 +1,18 @@
 import os
 import logging
-import urllib.parse
 
 from flask import request, jsonify
 from redis.exceptions import RedisError
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import HTTPException
 
-from backend.globals import cache
-from backend.bcssm_backend.cache_utils import get_ttl_registry
 from backend.bcssm_backend.exceptions import BaseError
 from backend.bcssm_backend.utils import (
-    clear_user_cache, clear_duty_cache, clear_feedback_cache, clear_all_cache
+    clear_user_cache, clear_duty_cache, clear_feedback_cache, clear_all_cache,
+    get_cache_status, get_cache_info, _redact_redis_url,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _fmt_ttl(ttl: int) -> str:
-    if ttl >= 3600:
-        hours = ttl // 3600
-        return f"{hours} hour{'s' if hours != 1 else ''}"
-    if ttl >= 60:
-        minutes = ttl // 60
-        return f"{minutes} minute{'s' if minutes != 1 else ''}"
-    return f"{ttl} second{'s' if ttl != 1 else ''}"
-
-
-def _redact_redis_url(url: str) -> str:
-    parsed = urllib.parse.urlparse(url)
-    host = parsed.hostname or 'localhost'
-    port = parsed.port or 6379
-    return f"{host}:{port}"
 
 
 def init_admin_routes(app):
@@ -68,25 +49,7 @@ def init_admin_routes(app):
     @app.route("/api/admin/cache/status", methods=['GET'])
     def cache_status():
         try:
-            test_key = 'status_test'
-            cache.set(test_key, 'working', timeout=10)
-            test_result = cache.get(test_key)
-            cache.delete(test_key)
-
-            return jsonify({
-                "status": "healthy" if test_result == 'working' else "unhealthy",
-                "redis_url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379')),
-                "default_timeout": 300,
-                "test_result": test_result,
-                "cache_type": "RedisCache",
-                "available_operations": {
-                    "clear_users": "/api/admin/cache/clear (POST with type: users)",
-                    "clear_duties": "/api/admin/cache/clear (POST with type: duties)",
-                    "clear_feedback": "/api/admin/cache/clear (POST with type: feedback)",
-                    "clear_all": "/api/admin/cache/clear (POST with type: all)"
-                }
-            })
-
+            return jsonify(get_cache_status())
         except RedisError as e:
             app.logger.error("Cache status check failed: %s", e)
             return jsonify({
@@ -97,21 +60,7 @@ def init_admin_routes(app):
 
     @app.route("/api/admin/cache/info", methods=['GET'])
     def cache_info():
-        return jsonify({
-            "cache_config": {
-                "type": "RedisCache",
-                "url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379')),
-                "default_timeout": 300
-            },
-            "cached_functions": {
-                name: _fmt_ttl(ttl) for name, ttl in get_ttl_registry().items()
-            },
-            "management_endpoints": {
-                "status": "GET /api/admin/cache/status",
-                "clear": "POST /api/admin/cache/clear",
-                "info": "GET /api/admin/cache/info"
-            }
-        })
+        return jsonify(get_cache_info())
 
 
 def register_error_handlers(app):

--- a/backend/bcssm_backend/routes/admin.py
+++ b/backend/bcssm_backend/routes/admin.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import urllib.parse
 
 from flask import request, jsonify
 from redis.exceptions import RedisError
@@ -21,8 +22,16 @@ def _fmt_ttl(ttl: int) -> str:
         hours = ttl // 3600
         return f"{hours} hour{'s' if hours != 1 else ''}"
     if ttl >= 60:
-        return f"{ttl // 60} minutes"
-    return f"{ttl} seconds"
+        minutes = ttl // 60
+        return f"{minutes} minute{'s' if minutes != 1 else ''}"
+    return f"{ttl} second{'s' if ttl != 1 else ''}"
+
+
+def _redact_redis_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or 'localhost'
+    port = parsed.port or 6379
+    return f"{host}:{port}"
 
 
 def init_admin_routes(app):
@@ -66,7 +75,7 @@ def init_admin_routes(app):
 
             return jsonify({
                 "status": "healthy" if test_result == 'working' else "unhealthy",
-                "redis_url": os.getenv('REDIS_URL', 'redis://localhost:6379'),
+                "redis_url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379')),
                 "default_timeout": 300,
                 "test_result": test_result,
                 "cache_type": "RedisCache",
@@ -83,7 +92,7 @@ def init_admin_routes(app):
             return jsonify({
                 "status": "unhealthy",
                 "error": "Cache status check failed",
-                "redis_url": os.getenv('REDIS_URL', 'redis://localhost:6379')
+                "redis_url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379'))
             }), 500
 
     @app.route("/api/admin/cache/info", methods=['GET'])
@@ -91,7 +100,7 @@ def init_admin_routes(app):
         return jsonify({
             "cache_config": {
                 "type": "RedisCache",
-                "url": os.getenv('REDIS_URL', 'redis://localhost:6379'),
+                "url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379')),
                 "default_timeout": 300
             },
             "cached_functions": {

--- a/backend/bcssm_backend/routes/admin.py
+++ b/backend/bcssm_backend/routes/admin.py
@@ -1,0 +1,130 @@
+import os
+import logging
+
+from flask import request, jsonify
+from redis.exceptions import RedisError
+from sqlalchemy.exc import SQLAlchemyError
+from werkzeug.exceptions import HTTPException
+
+from backend.globals import cache
+from backend.bcssm_backend.cache_utils import get_ttl_registry
+from backend.bcssm_backend.exceptions import BaseError
+from backend.bcssm_backend.utils import (
+    clear_user_cache, clear_duty_cache, clear_feedback_cache, clear_all_cache
+)
+
+logger = logging.getLogger(__name__)
+
+
+def init_admin_routes(app):
+    @app.route("/api/admin/cache/clear", methods=['POST'])
+    def clear_cache_endpoint():
+        try:
+            data = request.get_json() if request.is_json else {}
+            cache_type = data.get('type', 'all')
+
+            if cache_type == 'users':
+                clear_user_cache()
+                message = "Cleared user-related caches"
+            elif cache_type == 'duties':
+                clear_duty_cache()
+                message = "Cleared duty-related caches"
+            elif cache_type == 'feedback':
+                clear_feedback_cache()
+                message = "Cleared feedback caches"
+            elif cache_type == 'all':
+                clear_all_cache()
+                message = "Cleared all caches"
+            else:
+                return jsonify({
+                    "success": False,
+                    "error": "Invalid cache type. Use: users, duties, feedback, or all"
+                }), 400
+
+            return jsonify({"success": True, "message": message, "cache_type": cache_type})
+
+        except RedisError as e:
+            app.logger.error("Cache clearing failed: %s", e)
+            return jsonify({"success": False, "error": "Cache clearing failed"}), 500
+
+    @app.route("/api/admin/cache/status", methods=['GET'])
+    def cache_status():
+        try:
+            test_key = 'status_test'
+            cache.set(test_key, 'working', timeout=10)
+            test_result = cache.get(test_key)
+            cache.delete(test_key)
+
+            return jsonify({
+                "status": "healthy" if test_result == 'working' else "unhealthy",
+                "redis_url": os.getenv('REDIS_URL', 'redis://localhost:6379'),
+                "default_timeout": 300,
+                "test_result": test_result,
+                "cache_type": "RedisCache",
+                "available_operations": {
+                    "clear_users": "/api/admin/cache/clear (POST with type: users)",
+                    "clear_duties": "/api/admin/cache/clear (POST with type: duties)",
+                    "clear_feedback": "/api/admin/cache/clear (POST with type: feedback)",
+                    "clear_all": "/api/admin/cache/clear (POST with type: all)"
+                }
+            })
+
+        except RedisError as e:
+            app.logger.error("Cache status check failed: %s", e)
+            return jsonify({
+                "status": "unhealthy",
+                "error": "Cache status check failed",
+                "redis_url": os.getenv('REDIS_URL', 'redis://localhost:6379')
+            }), 500
+
+    @app.route("/api/admin/cache/info", methods=['GET'])
+    def cache_info():
+        def _fmt(ttl):
+            if ttl >= 3600:
+                return f"{ttl // 3600} hour{'s' if ttl // 3600 != 1 else ''}"
+            return f"{ttl // 60} minutes"
+
+        return jsonify({
+            "cache_config": {
+                "type": "RedisCache",
+                "url": os.getenv('REDIS_URL', 'redis://localhost:6379'),
+                "default_timeout": 300
+            },
+            "cached_functions": {
+                name: _fmt(ttl) for name, ttl in get_ttl_registry().items()
+            },
+            "management_endpoints": {
+                "status": "GET /api/admin/cache/status",
+                "clear": "POST /api/admin/cache/clear",
+                "info": "GET /api/admin/cache/info"
+            }
+        })
+
+
+def register_error_handlers(app):
+    @app.errorhandler(BaseError)
+    def handle_bcssm_error(e):
+        app.logger.error("Application error: %s", e.message)
+        return jsonify({"error": e.message}), e.status_code
+
+    @app.errorhandler(SQLAlchemyError)
+    def handle_db_error(e):
+        app.logger.error("Unhandled database error: %s", e)
+        return jsonify({"error": "A database error occurred"}), 500
+
+    @app.errorhandler(404)
+    def handle_404(e):
+        if request.path.startswith('/api/'):
+            return jsonify({"error": "Resource not found"}), 404
+        return e
+
+    @app.errorhandler(405)
+    def handle_405(e):
+        return jsonify({"error": "Method not allowed"}), 405
+
+    @app.errorhandler(Exception)
+    def handle_exception(e):
+        if isinstance(e, HTTPException):
+            return e
+        app.logger.error("Unhandled exception: %s", e)
+        return jsonify({"error": "Internal server error"}), 500

--- a/backend/bcssm_backend/routes/devos_feedback.py
+++ b/backend/bcssm_backend/routes/devos_feedback.py
@@ -1,49 +1,11 @@
 from datetime import datetime
 from flask import request, jsonify
 from sqlalchemy.exc import SQLAlchemyError
-from backend.bcssm_backend.utils import execute_query
+from backend.bcssm_backend.utils import get_feedback_by_date, get_user_info, save_devos_feedback
 from backend.bcssm_backend.auth import get_username_from_request, get_user_id_from_request
 
 import logging
 logger = logging.getLogger(__name__)
-
-
-def get_feedback_by_date(date_str):
-    """Fetch feedback from the database for a given date."""
-    query = """
-    SELECT s.name AS section_name, f.feedback
-    FROM sections s
-    LEFT JOIN feedback f ON s.id = f.section_id AND f.date = :date;
-    """
-    try:
-        feedback_rows = execute_query(query, {"date": date_str})
-        daily_feedback = {row[0]: row[1] if row[1] is not None else "No feedback available" for row in feedback_rows}
-        return daily_feedback, None  # Always return two values
-    except SQLAlchemyError as e:
-        logger.error("Error in get_feedback_by_date for date %s: %s", date_str, e)
-        return None, "An error occurred while fetching feedback"
-
-
-def get_user_info(user_name):
-    """Fetch user role and section for permission checking."""
-    user_info_query = """
-    SELECT u.name, u.role, s.name AS section_name
-    FROM users u
-    LEFT JOIN sections s ON u.section_id = s.id
-    WHERE u.name = :user_name;
-    """
-    try:
-        user_rows = execute_query(user_info_query, {"user_name": user_name})
-        if user_rows:
-            return {
-                "name": user_rows[0][0],
-                "role": user_rows[0][1],
-                "section": user_rows[0][2],
-            }
-        return None  # User not found
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch user info for %s: %s", user_name, e)
-        raise
 
 
 def init_feedback_routes(app):
@@ -106,34 +68,11 @@ def init_feedback_routes(app):
         if not date_str or not section_name or new_feedback is None:
             return jsonify({'error': 'Missing date, section, or feedback'}), 400
 
-        # Retrieve the section ID
-        sec_query = "SELECT id FROM sections WHERE name = :section_name;"
         try:
-            sec_rows = execute_query(sec_query, {'section_name': section_name})
-        except SQLAlchemyError as e:
-            logger.error("Failed to fetch section '%s': %s", section_name, e)
-            return jsonify({'error': 'Internal server error'}), 500
-        if not sec_rows:
-            return jsonify({'error': f"Section '{section_name}' not found"}), 400
-        section_id = sec_rows[0][0]
-
-        try:
-            # Upsert feedback (PostgreSQL syntax)
-            upsert_query = """
-                INSERT INTO feedback (section_id, date, feedback, last_edited_by, last_edited_at)
-                VALUES (:section_id, :date_str, :new_feedback, :editor_id, CURRENT_TIMESTAMP)
-                ON CONFLICT (section_id, date) DO UPDATE
-                  SET feedback = EXCLUDED.feedback,
-                      last_edited_by = EXCLUDED.last_edited_by,
-                      last_edited_at = EXCLUDED.last_edited_at;
-            """
-            execute_query(upsert_query, {
-                'section_id': section_id,
-                'date_str': date_str,
-                'new_feedback': new_feedback,
-                'editor_id': editor_id
-            })
+            save_devos_feedback(section_name, date_str, new_feedback, editor_id)
             return jsonify({'success': True}), 200
+        except ValueError as e:
+            return jsonify({'error': str(e)}), 400
         except SQLAlchemyError as e:
             logger.exception("Error editing feedback for date %s, section %s: %s", date_str, section_name, e)
             return jsonify({'error': 'Internal server error'}), 500

--- a/backend/bcssm_backend/routes/devos_feedback.py
+++ b/backend/bcssm_backend/routes/devos_feedback.py
@@ -3,6 +3,7 @@ from flask import request, jsonify
 from sqlalchemy.exc import SQLAlchemyError
 from backend.bcssm_backend.utils import get_feedback_by_date, get_user_info, save_devos_feedback
 from backend.bcssm_backend.auth import get_username_from_request, get_user_id_from_request
+from backend.bcssm_backend.exceptions import ValidationError
 
 import logging
 logger = logging.getLogger(__name__)
@@ -71,8 +72,8 @@ def init_feedback_routes(app):
         try:
             save_devos_feedback(section_name, date_str, new_feedback, editor_id)
             return jsonify({'success': True}), 200
-        except ValueError as e:
-            return jsonify({'error': str(e)}), 400
+        except ValidationError as e:
+            return jsonify({'error': e.message}), e.status_code
         except SQLAlchemyError as e:
             logger.exception("Error editing feedback for date %s, section %s: %s", date_str, section_name, e)
             return jsonify({'error': 'Internal server error'}), 500

--- a/backend/bcssm_backend/routes/system.py
+++ b/backend/bcssm_backend/routes/system.py
@@ -3,6 +3,7 @@ import os
 from flask import jsonify, send_from_directory
 from redis.exceptions import RedisError
 
+from backend.bcssm_backend.exceptions import CacheError
 from backend.bcssm_backend.utils import get_all_sections, get_health_status
 
 
@@ -19,7 +20,7 @@ def init_system_routes(app):
     def health_check():
         try:
             return jsonify(get_health_status())
-        except RedisError as e:
+        except (RedisError, CacheError) as e:
             app.logger.error("Health check failed: %s", e)
             return jsonify({
                 "status": "unhealthy",

--- a/backend/bcssm_backend/routes/system.py
+++ b/backend/bcssm_backend/routes/system.py
@@ -1,18 +1,9 @@
 import os
-import urllib.parse
 
 from flask import jsonify, send_from_directory
 from redis.exceptions import RedisError
 
-from backend.globals import cache
-from backend.bcssm_backend.utils import get_all_sections
-
-
-def _redact_redis_url(url: str) -> str:
-    parsed = urllib.parse.urlparse(url)
-    host = parsed.hostname or 'localhost'
-    port = parsed.port or 6379
-    return f"{host}:{port}"
+from backend.bcssm_backend.utils import get_all_sections, get_health_status
 
 
 def init_system_routes(app):
@@ -27,21 +18,7 @@ def init_system_routes(app):
     @app.route("/api/health")
     def health_check():
         try:
-            cache.set('health_test', 'ok', timeout=10)
-            cache_status = cache.get('health_test') == 'ok'
-            cache.delete('health_test')
-
-            health_info = {
-                "status": "healthy",
-                "database": "connected",
-                "cache": "healthy" if cache_status else "unhealthy",
-                "environment": os.getenv('FLASK_ENV', 'development'),
-                "redis_url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379'))
-            }
-            if not cache_status:
-                health_info["status"] = "degraded"
-            return jsonify(health_info)
-
+            return jsonify(get_health_status())
         except RedisError as e:
             app.logger.error("Health check failed: %s", e)
             return jsonify({

--- a/backend/bcssm_backend/routes/system.py
+++ b/backend/bcssm_backend/routes/system.py
@@ -1,0 +1,67 @@
+import os
+
+from flask import jsonify, send_from_directory
+from redis.exceptions import RedisError
+
+from backend.globals import cache
+from backend.bcssm_backend.utils import get_all_sections
+
+
+def init_system_routes(app):
+    @app.route("/api/sections")
+    def api_sections():
+        sections = get_all_sections()
+        if isinstance(sections, dict) and "error" in sections:
+            app.logger.error("api_sections failed: %s", sections["error"])
+            return jsonify({"error": "Failed to fetch sections"}), 500
+        return jsonify(sections)
+
+    @app.route("/api/health")
+    def health_check():
+        try:
+            cache.set('health_test', 'ok', timeout=10)
+            cache_status = cache.get('health_test') == 'ok'
+            cache.delete('health_test')
+
+            health_info = {
+                "status": "healthy",
+                "database": "connected",
+                "cache": "healthy" if cache_status else "unhealthy",
+                "environment": os.getenv('FLASK_ENV', 'development'),
+                "redis_url": os.getenv('REDIS_URL', 'redis://localhost:6379')
+            }
+            if not cache_status:
+                health_info["status"] = "degraded"
+            return jsonify(health_info)
+
+        except RedisError as e:
+            app.logger.error("Health check failed: %s", e)
+            return jsonify({
+                "status": "unhealthy",
+                "database": "unknown",
+                "cache": "unhealthy",
+                "error": "Health check failed",
+            }), 500
+
+    @app.route("/", defaults={"path": ""})
+    @app.route("/<path:path>")
+    def serve_react(path):
+        app.logger.info("React route fallback triggered for path: %s", path)
+
+        if path.startswith(('api/', 'get-', 'select-', 'devos-', 'duty-')):
+            return app.send_static_file('index.html')
+
+        safe_path = os.path.normpath(path).lstrip("/\\")
+        requested_path = os.path.join(app.static_folder, safe_path)
+        requested_path = os.path.realpath(requested_path)
+        if not requested_path.startswith(os.path.realpath(app.static_folder)):
+            app.logger.warning("Attempted directory traversal detected: %s", path)
+            return send_from_directory(app.static_folder, "index.html")
+        if os.path.isfile(requested_path):
+            return send_from_directory(
+                app.static_folder,
+                os.path.relpath(requested_path, app.static_folder)
+            )
+
+        app.logger.info("React serving index.html for path: /%s", path)
+        return send_from_directory(app.static_folder, "index.html")

--- a/backend/bcssm_backend/routes/system.py
+++ b/backend/bcssm_backend/routes/system.py
@@ -1,10 +1,18 @@
 import os
+import urllib.parse
 
 from flask import jsonify, send_from_directory
 from redis.exceptions import RedisError
 
 from backend.globals import cache
 from backend.bcssm_backend.utils import get_all_sections
+
+
+def _redact_redis_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or 'localhost'
+    port = parsed.port or 6379
+    return f"{host}:{port}"
 
 
 def init_system_routes(app):
@@ -28,7 +36,7 @@ def init_system_routes(app):
                 "database": "connected",
                 "cache": "healthy" if cache_status else "unhealthy",
                 "environment": os.getenv('FLASK_ENV', 'development'),
-                "redis_url": os.getenv('REDIS_URL', 'redis://localhost:6379')
+                "redis_url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379'))
             }
             if not cache_status:
                 health_info["status"] = "degraded"
@@ -52,9 +60,9 @@ def init_system_routes(app):
             return app.send_static_file('index.html')
 
         safe_path = os.path.normpath(path).lstrip("/\\")
-        requested_path = os.path.join(app.static_folder, safe_path)
-        requested_path = os.path.realpath(requested_path)
-        if not requested_path.startswith(os.path.realpath(app.static_folder)):
+        static_root = os.path.realpath(app.static_folder)
+        requested_path = os.path.realpath(os.path.join(static_root, safe_path))
+        if os.path.commonpath([requested_path, static_root]) != static_root:
             app.logger.warning("Attempted directory traversal detected: %s", path)
             return send_from_directory(app.static_folder, "index.html")
         if os.path.isfile(requested_path):

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -10,6 +10,7 @@ from redis.exceptions import RedisError
 
 from backend.globals import db, cache
 from backend.bcssm_backend.cache_utils import cached_result
+from backend.bcssm_backend.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -365,7 +366,7 @@ def save_devos_feedback(section_name: str, date_str: str, new_feedback: str, edi
         'editor_id': editor_id
     })
     if not rows:
-        raise ValueError(f"Section '{section_name}' not found")
+        raise ValidationError("Section not found")
 
 
 def clear_duty_cache():

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -50,14 +50,12 @@ def execute_query(query, params=None):
         with db.session.begin():
             logger.info("Executing query: %s with params: %s", query, params)
             result = db.session.execute(text(query), params)
-
-        # Return rows only if the query expects a result
-        if result.returns_rows:
-            rows = result.fetchall()
-            logger.info("Raw rows fetched: %s", rows)
-            return rows
-        logger.info("Query executed successfully with no rows returned.")
-        return None
+            if result.returns_rows:
+                rows = result.fetchall()
+                logger.info("Raw rows fetched: %s", rows)
+                return rows
+            logger.info("Query executed successfully with no rows returned.")
+            return None
 
     except SQLAlchemyError as e:
         db.session.rollback()
@@ -318,7 +316,7 @@ def get_feedback_by_date(date_str):
     LEFT JOIN feedback f ON s.id = f.section_id AND f.date = :date;
     """
     try:
-        feedback_rows = execute_query(query, {"date": date_str})
+        feedback_rows = execute_readonly_query(query, {"date": date_str})
         daily_feedback = {row[0]: row[1] if row[1] is not None else "No feedback available" for row in feedback_rows}
         return daily_feedback, None
     except SQLAlchemyError as e:
@@ -334,7 +332,7 @@ def get_user_info(user_name):
     WHERE u.name = :user_name;
     """
     try:
-        user_rows = execute_query(user_info_query, {"user_name": user_name})
+        user_rows = execute_readonly_query(user_info_query, {"user_name": user_name})
         if user_rows:
             return {
                 "name": user_rows[0][0],
@@ -348,28 +346,26 @@ def get_user_info(user_name):
 
 
 def save_devos_feedback(section_name: str, date_str: str, new_feedback: str, editor_id: int) -> None:
-    sec_rows = execute_query(
-        "SELECT id FROM sections WHERE name = :section_name;",
-        {'section_name': section_name}
-    )
-    if not sec_rows:
-        raise ValueError(f"Section '{section_name}' not found")
-    section_id = sec_rows[0][0]
-
-    upsert_query = """
+    # Single-query approach: INSERT...SELECT eliminates the TOCTOU gap between
+    # the section lookup and the upsert. RETURNING lets us detect a missing section.
+    query = """
         INSERT INTO feedback (section_id, date, feedback, last_edited_by, last_edited_at)
-        VALUES (:section_id, :date_str, :new_feedback, :editor_id, CURRENT_TIMESTAMP)
+        SELECT s.id, :date_str, :new_feedback, :editor_id, CURRENT_TIMESTAMP
+        FROM sections s WHERE s.name = :section_name
         ON CONFLICT (section_id, date) DO UPDATE
           SET feedback = EXCLUDED.feedback,
               last_edited_by = EXCLUDED.last_edited_by,
-              last_edited_at = EXCLUDED.last_edited_at;
+              last_edited_at = EXCLUDED.last_edited_at
+        RETURNING section_id;
     """
-    execute_query(upsert_query, {
-        'section_id': section_id,
+    rows = execute_query(query, {
+        'section_name': section_name,
         'date_str': date_str,
         'new_feedback': new_feedback,
         'editor_id': editor_id
     })
+    if not rows:
+        raise ValueError(f"Section '{section_name}' not found")
 
 
 def clear_duty_cache():
@@ -528,9 +524,10 @@ def clear_user_cache():
         cache.delete('users:all:list')
         cache.delete('sections:all:list')
         cache.delete('sections:with_users:all')
-        cache.delete('sections:with_users:all_v2')  # Old cache key
-        cache.delete('sections:with_users:all_v3')  # Old cache key with week data
-        cache.delete('sections:with_users:all_v4')  # New cache key with better week handling
+        cache.delete('sections:with_users:all_v2')
+        cache.delete('sections:with_users:all_v3')
+        cache.delete('sections:with_users:all_v4')
+        cache.delete('sections:with_users:all_v6')
         cache.delete('sections:statistics:summary')
         
         # Clear individual section caches using pattern matching if supported

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from redis.exceptions import RedisError
 
 from backend.globals import db, cache
+from backend.bcssm_backend.cache_utils import cached_result
 
 logger = logging.getLogger(__name__)
 
@@ -63,139 +64,83 @@ def execute_query(query, params=None):
         logger.error("Query failed. Query: %s, Params: %s, Error: %s", query, params, e)
         raise
 
+@cached_result('users:all:list', 900, on_error=[])
 def get_all_users():
-    """
-    Optimized query with Redis caching and better ordering.
-    Cache timeout: 15 minutes (users don't change frequently)
-    """
-    cache_key = 'users:all:list'
-    
-    # Try to get from cache first
-    cached_users = cache.get(cache_key)
-    if cached_users is not None:
-        logger.info("Retrieved users from cache")
-        return cached_users
-    
     query = """
-    SELECT 
-        u.name, 
-        COALESCE(s.name, 'Unassigned') AS section,  
-        u.role, 
-        COALESCE(dt.name, 'No Team') AS team 
+    SELECT
+        u.name,
+        COALESCE(s.name, 'Unassigned') AS section,
+        u.role,
+        COALESCE(dt.name, 'No Team') AS team
     FROM users u
     LEFT JOIN sections s ON u.section_id = s.id
     LEFT JOIN duty_teams dt ON u.duty_team_id = dt.id
-    ORDER BY 
-        CASE 
-            WHEN POSITION(' ' IN u.name) > 0 
+    ORDER BY
+        CASE
+            WHEN POSITION(' ' IN u.name) > 0
             THEN SUBSTRING(u.name FROM POSITION(' ' IN u.name) + 1)
-            ELSE u.name 
+            ELSE u.name
         END,
         u.name;
     """
-    try:
-        logger.info("Starting query execution for get_all_users...")
-        rows = execute_readonly_query(query)
-        logger.info("Query returned rows: %s", rows)
+    rows = execute_readonly_query(query)
+    return [row[0] for row in rows]
 
-        # Extract only the names for the dropdown
-        user_names = [row[0] for row in rows]
-        logger.info("Fetched user names: %s", user_names)
-        
-        # Cache the results
-        cache.set(cache_key, user_names, timeout=900)  # 15 minutes
-        logger.info("Cached users list")
-        
-        return user_names
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch users: %s", e)
-        return []
+def _user_duty_key(user_name):
+    day = (datetime.now().weekday() + 1) % 7
+    cycle = get_current_cycle_week()
+    return f'user:duty:{user_name}:day{day}:cycle{cycle}'
 
+
+@cached_result(_user_duty_key, 600)
 def get_user_duty(user_name):
-    """
-    Optimized with Redis caching and pre-calculated cycle week.
-    Cache timeout: 10 minutes (duty assignments change daily)
-    """
     current_day = (datetime.now().weekday() + 1) % 7
     current_cycle = get_current_cycle_week()
-    
-    # Create cache key that includes day and cycle for accurate caching
-    cache_key = f'user:duty:{user_name}:day{current_day}:cycle{current_cycle}'
-
-    # Try to get from cache first
-    cached_duty = cache.get(cache_key)
-    if cached_duty is not None:
-        logger.info("Retrieved user duty from cache for %s", user_name)
-        return cached_duty
-    
     query = """
-    SELECT 
-        u.name AS user_name, 
-        COALESCE(s.name, 'Unassigned') AS section, 
-        u.role, 
+    SELECT
+        u.name AS user_name,
+        COALESCE(s.name, 'Unassigned') AS section,
+        u.role,
         COALESCE(dt.name, 'No Team') AS team,
         COALESCE(d.name, 'No Duty') AS duty
     FROM users u
     LEFT JOIN sections s ON u.section_id = s.id
     LEFT JOIN duty_teams dt ON u.duty_team_id = dt.id
-    LEFT JOIN duty_schedule ds ON dt.id = ds.duty_team_id 
-        AND ds.day = :day 
+    LEFT JOIN duty_schedule ds ON dt.id = ds.duty_team_id
+        AND ds.day = :day
         AND ds.cycle_week = :cycle_week
     LEFT JOIN duties d ON ds.duty_id = d.id
     WHERE u.name = :user_name;
     """
-    try:
-        # Execute the query with the user's name, current day, and cycle week
-        result = execute_readonly_query(query, {
-            "user_name": user_name, 
-            "day": current_day,
-            "cycle_week": current_cycle
-        })
-        
-        if not result:
-            duty_data = {"error": "User not found or no duty assigned"}
-        else:
-            # Extract the user's duty information
-            row = result[0]
-            if len(row) < 5:
-                logger.error("Unexpected row format in get_user_duty for %s: %s", user_name, row)
-                duty_data = {"error": "Unexpected data format from database"}
-            else:
-                duty_data = {
-                    "user": row[0],  # user_name
-                    "section": row[1],  # section name
-                    "role": row[2],  # role
-                    "team": row[3],  # team name
-                    "duty": row[4],  # duty name
-                }
-        
-        # Cache the results (even errors, to avoid repeated failed queries)
-        cache.set(cache_key, duty_data, timeout=600)  # 10 minutes
-        logger.info("Cached user duty for %s", user_name)
-        
-        return duty_data
+    result = execute_readonly_query(query, {
+        "user_name": user_name,
+        "day": current_day,
+        "cycle_week": current_cycle
+    })
+    if not result:
+        return {"error": "User not found or no duty assigned"}
+    row = result[0]
+    if len(row) < 5:
+        logger.error("Unexpected row format in get_user_duty for %s: %s", user_name, row)
+        return {"error": "Unexpected data format from database"}
+    return {
+        "user": row[0],
+        "section": row[1],
+        "role": row[2],
+        "team": row[3],
+        "duty": row[4],
+    }
 
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch duty for user %s: %s", user_name, e)
-        raise
+def _todays_duties_key(user_name):
+    day = (datetime.now().weekday() + 1) % 7
+    cycle = get_current_cycle_week()
+    return f'duties:today:day{day}:cycle{cycle}:user{user_name}'
 
+
+@cached_result(_todays_duties_key, 1800, error_ttl=60, on_error=[])
 def get_todays_duties(user_name):
-    """
-    Cached today's duties with day-specific cache key.
-    Cache timeout: 30 minutes (duties are daily but don't change frequently)
-    """
     current_day = (datetime.now().weekday() + 1) % 7
     current_cycle = get_current_cycle_week()
-    
-    # Cache key includes day and cycle for accuracy
-    cache_key = f'duties:today:day{current_day}:cycle{current_cycle}:user{user_name}'
-    
-    # Try to get from cache first
-    cached_duties = cache.get(cache_key)
-    if cached_duties is not None:
-        logger.info("Retrieved today's duties from cache")
-        return cached_duties
-    
     query = '''
     SELECT
         d.id,
@@ -221,57 +166,33 @@ def get_todays_duties(user_name):
     JOIN duties d ON ds.duty_id = d.id
     JOIN duty_teams dt ON ds.duty_team_id = dt.id
     LEFT JOIN users u ON u.duty_team_id = dt.id
-    WHERE ds.day = :day 
+    WHERE ds.day = :day
         AND ds.cycle_week = :cycle_week
     GROUP BY d.id, d.name, d.duty_description, dt.name
     ORDER BY d.name;
     '''
-    
-    try:
-        rows = execute_readonly_query(query, {
-            "day": current_day, 
-            "user_name": user_name,
-            "cycle_week": current_cycle
-        })
-        
-        duties = []
-        for row in rows:
-            duties.append({
-                "id": row[0],
-                "name": row[1],
-                "duty_description": row[2],
-                "team_name": row[3],
-                "members": row[4] or [],
-                "is_current_user": row[5],
-            })
-        
-        # Cache the results
-        cache.set(cache_key, duties, timeout=1800)  # 30 minutes
-        logger.info("Cached today's duties")
-        
-        return duties
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch today's duties for user %s: %s", user_name, e)
+    rows = execute_readonly_query(query, {
+        "day": current_day,
+        "user_name": user_name,
+        "cycle_week": current_cycle
+    })
+    return [
+        {
+            "id": row[0],
+            "name": row[1],
+            "duty_description": row[2],
+            "team_name": row[3],
+            "members": row[4] or [],
+            "is_current_user": row[5],
+        }
+        for row in rows
+    ]
+def _duty_schedule_key():
+    return f'duties:schedule:14day:{datetime.now().date()}'
 
-        # Cache empty result for short time to avoid repeated failures
-        cache.set(cache_key, [], timeout=60)  # 1 minute
 
-        return []
+@cached_result(_duty_schedule_key, 7200, error_ttl=60, on_error=[])
 def get_duty_schedule():
-    """
-    Cached duty schedule with date-based cache key.
-    Cache timeout: 2 hours (schedule doesn't change frequently)
-    """
-    # Create cache key based on current date to ensure freshness
-    today = datetime.now().date()
-    cache_key = f'duties:schedule:14day:{today}'
-    
-    # Try to get from cache first
-    cached_schedule = cache.get(cache_key)
-    if cached_schedule is not None:
-        logger.info("Retrieved duty schedule from cache")
-        return cached_schedule
-    
     start_date = datetime(2025, 7, 5)
     
     # Pre-calculate all day/cycle combinations we need
@@ -323,19 +244,9 @@ def get_duty_schedule():
     ORDER BY ds.day, d.name;
     '''
 
-    try:
-        # Extract unique days and cycles for the query
-        days = list(set(combo[0] for combo in day_cycle_combinations))
-        cycles = list(set(combo[1] for combo in day_cycle_combinations))
-        
-        rows = execute_readonly_query(query, {"days": days, "cycles": cycles})
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch 2-week duty schedule: %s", e)
-
-        # Cache empty result for short time to avoid repeated failures
-        cache.set(cache_key, [], timeout=60)  # 1 minute
-
-        return []
+    days = list(set(combo[0] for combo in day_cycle_combinations))
+    cycles = list(set(combo[1] for combo in day_cycle_combinations))
+    rows = execute_readonly_query(query, {"days": days, "cycles": cycles})
 
     # Group duties by (day, cycle_week) combination
     duty_lookup = defaultdict(list)
@@ -362,61 +273,23 @@ def get_duty_schedule():
             "duties": duties_for_date
         })
 
-    # Cache the results
-    cache.set(cache_key, schedule, timeout=7200)  # 2 hours
-    logger.info("Cached duty schedule")
-
     return schedule
 
+
+@cached_result('sections:all:list', 3600, error_ttl=60,
+               on_error=lambda e: {"error": f"Failed to fetch sections: {e}"})
 def get_all_sections():
-    """
-    Cached sections query with long timeout since sections rarely change.
-    Cache timeout: 1 hour
-    """
-    cache_key = 'sections:all:list'
-    
-    # Try to get from cache first
-    cached_sections = cache.get(cache_key)
-    if cached_sections is not None:
-        logger.info("Retrieved sections from cache")
-        return cached_sections
-    
     query = """
     SELECT name
     FROM sections
     ORDER BY display_order, name;
     """
-    try:
-        result = execute_readonly_query(query)
-        sections = [row[0] for row in result]
-        
-        # Cache the results
-        cache.set(cache_key, sections, timeout=3600)  # 1 hour
-        logger.info("Cached sections list")
-        
-        return sections
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch sections: %s", e)
-        error_data = {"error": f"Failed to fetch sections: {e}"}
+    result = execute_readonly_query(query)
+    return [row[0] for row in result]
 
-        # Cache error for short time
-        cache.set(cache_key, error_data, timeout=60)  # 1 minute
-
-        return error_data
-
+@cached_result(lambda section: f'users:section:{section}', 1800, error_ttl=60,
+               on_error=lambda e: {"error": f"Failed to fetch users by section: {e}"})
 def get_users_by_section(section):
-    """
-    Cached users by section query.
-    Cache timeout: 30 minutes
-    """
-    cache_key = f'users:section:{section}'
-    
-    # Try to get from cache first
-    cached_users = cache.get(cache_key)
-    if cached_users is not None:
-        logger.info("Retrieved users by section from cache for %s", section)
-        return cached_users
-    
     query = """
     SELECT u.name, u.role
     FROM users u
@@ -424,59 +297,80 @@ def get_users_by_section(section):
     WHERE s.name = :section
     ORDER BY u.name;
     """
-    try:
-        result = execute_readonly_query(query, {"section": section})
-        users = [{"name": row[0], "role": row[1]} for row in result]
-        
-        # Cache the results
-        cache.set(cache_key, users, timeout=1800)  # 30 minutes
-        logger.info("Cached users by section for %s", section)
-        
-        return users
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch users by section %s: %s", section, e)
-        error_data = {"error": f"Failed to fetch users by section: {e}"}
+    result = execute_readonly_query(query, {"section": section})
+    return [{"name": row[0], "role": row[1]} for row in result]
 
-        # Cache error for short time
-        cache.set(cache_key, error_data, timeout=60)  # 1 minute
-
-        return error_data
-
+@cached_result('feedback:dates:all', 7200, error_ttl=60,
+               on_error=lambda e: {"error": f"Failed to fetch feedback dates: {e}"})
 def get_all_feedback_dates():
-    """
-    Cached feedback dates with long timeout since they don't change frequently.
-    Cache timeout: 2 hours
-    """
-    cache_key = 'feedback:dates:all'
-    
-    # Try to get from cache first
-    cached_dates = cache.get(cache_key)
-    if cached_dates is not None:
-        logger.info("Retrieved feedback dates from cache")
-        return cached_dates
-    
     query = """
     SELECT DISTINCT date
     FROM feedback_records
     ORDER BY date DESC;
     """
+    result = execute_readonly_query(query)
+    return [row[0] for row in result]
+
+def get_feedback_by_date(date_str):
+    query = """
+    SELECT s.name AS section_name, f.feedback
+    FROM sections s
+    LEFT JOIN feedback f ON s.id = f.section_id AND f.date = :date;
+    """
     try:
-        result = execute_readonly_query(query)
-        dates = [row[0] for row in result]
-        
-        # Cache the results
-        cache.set(cache_key, dates, timeout=7200)  # 2 hours
-        logger.info("Cached feedback dates")
-        
-        return dates
+        feedback_rows = execute_query(query, {"date": date_str})
+        daily_feedback = {row[0]: row[1] if row[1] is not None else "No feedback available" for row in feedback_rows}
+        return daily_feedback, None
     except SQLAlchemyError as e:
-        logger.error("Failed to fetch feedback dates: %s", e)
-        error_data = {"error": f"Failed to fetch feedback dates: {e}"}
+        logger.error("Error in get_feedback_by_date for date %s: %s", date_str, e)
+        return None, "An error occurred while fetching feedback"
 
-        # Cache error for short time
-        cache.set(cache_key, error_data, timeout=60)  # 1 minute
 
-        return error_data
+def get_user_info(user_name):
+    user_info_query = """
+    SELECT u.name, u.role, s.name AS section_name
+    FROM users u
+    LEFT JOIN sections s ON u.section_id = s.id
+    WHERE u.name = :user_name;
+    """
+    try:
+        user_rows = execute_query(user_info_query, {"user_name": user_name})
+        if user_rows:
+            return {
+                "name": user_rows[0][0],
+                "role": user_rows[0][1],
+                "section": user_rows[0][2],
+            }
+        return None
+    except SQLAlchemyError as e:
+        logger.error("Failed to fetch user info for %s: %s", user_name, e)
+        raise
+
+
+def save_devos_feedback(section_name: str, date_str: str, new_feedback: str, editor_id: int) -> None:
+    sec_rows = execute_query(
+        "SELECT id FROM sections WHERE name = :section_name;",
+        {'section_name': section_name}
+    )
+    if not sec_rows:
+        raise ValueError(f"Section '{section_name}' not found")
+    section_id = sec_rows[0][0]
+
+    upsert_query = """
+        INSERT INTO feedback (section_id, date, feedback, last_edited_by, last_edited_at)
+        VALUES (:section_id, :date_str, :new_feedback, :editor_id, CURRENT_TIMESTAMP)
+        ON CONFLICT (section_id, date) DO UPDATE
+          SET feedback = EXCLUDED.feedback,
+              last_edited_by = EXCLUDED.last_edited_by,
+              last_edited_at = EXCLUDED.last_edited_at;
+    """
+    execute_query(upsert_query, {
+        'section_id': section_id,
+        'date_str': date_str,
+        'new_feedback': new_feedback,
+        'editor_id': editor_id
+    })
+
 
 def clear_duty_cache():
     """Clear duty-related caches after duty data changes"""
@@ -505,21 +399,9 @@ def clear_all_cache():
     except RedisError as e:
         logger.warning("Failed to clear all caches: %s", e)
 
-# Add these functions to your backend/bcssm_backend/utils.py file
-
+@cached_result('sections:with_users:all_v6', 1800, error_ttl=60,
+               on_error=lambda e: {"error": f"Failed to fetch sections with users: {e}"})
 def get_all_sections_with_users():
-    """
-    Get all sections with their users, optimized with caching.
-    Cache timeout: 30 minutes (user assignments don't change frequently)
-    """
-    cache_key = 'sections:with_users:all_v6'  # Updated cache key for new sorting
-    
-    # Try to get from cache first
-    cached_data = cache.get(cache_key)
-    if cached_data is not None:
-        logger.info("Retrieved sections with users from cache")
-        return cached_data
-    
     # Optimized query using proper JOINs and leveraging indexes
     query = """
     SELECT 
@@ -552,74 +434,36 @@ def get_all_sections_with_users():
         u.name;
     """
     
-    try:
-        logger.info("Executing optimized query to fetch all sections with users")
-        rows = execute_readonly_query(query)
-        
-        # Group users by section efficiently
-        sections_dict = {}
-        
-        for row in rows:
-            section_name = row[0]
-            user_name = row[2]
-            display_role = row[3]
-            week = row[4]
-            
-            # Create section if it doesn't exist
-            if section_name not in sections_dict:
-                sections_dict[section_name] = {
-                    "name": section_name,
-                    "display_order": row[1],
-                    "users": [],
-                    "user_count": 0
-                }
-            
-            # Add user to section (user_name should always exist due to RIGHT JOIN)
-            if user_name:
-                user_data = {
-                    "name": user_name,
-                    "role": display_role,  # This is now the display_role
-                    "week": week  # Add the week field
-                }
-                
-                sections_dict[section_name]["users"].append(user_data)
-                sections_dict[section_name]["user_count"] += 1
-        
-        # Convert to list and sort by display_order (already sorted by query, but ensure consistency)
-        sections_list = list(sections_dict.values())
-        sections_list.sort(key=lambda x: (x["display_order"], x["name"]))
-        
-        # Cache the results
-        cache.set(cache_key, sections_list, timeout=1800)  # 30 minutes
-        logger.info("Cached sections with users data")
-        
-        return sections_list
-        
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch sections with users: %s", e)
-        error_data = {"error": f"Failed to fetch sections with users: {e}"}
-
-        # Cache error for short time
-        cache.set(cache_key, error_data, timeout=60)  # 1 minute
-
-        return error_data
+    rows = execute_readonly_query(query)
+    sections_dict = {}
+    for row in rows:
+        section_name = row[0]
+        user_name = row[2]
+        display_role = row[3]
+        week = row[4]
+        if section_name not in sections_dict:
+            sections_dict[section_name] = {
+                "name": section_name,
+                "display_order": row[1],
+                "users": [],
+                "user_count": 0
+            }
+        if user_name:
+            sections_dict[section_name]["users"].append({
+                "name": user_name,
+                "role": display_role,
+                "week": week
+            })
+            sections_dict[section_name]["user_count"] += 1
+    sections_list = list(sections_dict.values())
+    sections_list.sort(key=lambda x: (x["display_order"], x["name"]))
+    return sections_list
     
+@cached_result('sections:statistics:summary', 3600, error_ttl=60,
+               on_error=lambda e: {"error": f"Failed to fetch section statistics: {e}"})
 def get_section_statistics():
-    """
-    Get statistics about users across sections.
-    Cache timeout: 1 hour (statistics don't change frequently)
-    """
-    cache_key = 'sections:statistics:summary'
-    
-    # Try to get from cache first
-    cached_stats = cache.get(cache_key)
-    if cached_stats is not None:
-        logger.info("Retrieved section statistics from cache")
-        return cached_stats
-    
-    # Single optimized query to get all statistics
     query = """
-    SELECT 
+    SELECT
         COALESCE(s.name, 'Unassigned') AS section_name,
         COALESCE(s.display_order, 999) AS display_order,
         COUNT(u.id) AS total_users,
@@ -631,51 +475,22 @@ def get_section_statistics():
     GROUP BY s.id, s.name, s.display_order
     ORDER BY COALESCE(s.display_order, 999), COALESCE(s.name, 'Unassigned');
     """
-    
-    try:
-        rows = execute_readonly_query(query)
-        
-        statistics = []
-        for row in rows:
-            stat = {
-                "section_name": row[0],
-                "display_order": row[1],
-                "total_users": row[2],
-                "section_leaders": row[3],  # Now includes both Admin and Section Leader
-                "team_leaders": row[4],
-                "other_roles": row[5]
-            }
-            statistics.append(stat)
-        
-        # Cache the results
-        cache.set(cache_key, statistics, timeout=3600)  # 1 hour
-        logger.info("Cached section statistics")
-        
-        return statistics
-        
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch section statistics: %s", e)
-        error_data = {"error": f"Failed to fetch section statistics: {e}"}
+    rows = execute_readonly_query(query)
+    return [
+        {
+            "section_name": row[0],
+            "display_order": row[1],
+            "total_users": row[2],
+            "section_leaders": row[3],
+            "team_leaders": row[4],
+            "other_roles": row[5]
+        }
+        for row in rows
+    ]
 
-        # Cache error for short time
-        cache.set(cache_key, error_data, timeout=60)  # 1 minute
-
-        return error_data
-
+@cached_result(lambda section_name: f'users:section:{section_name}:detailed', 1800, error_ttl=60,
+               on_error=lambda e: {"error": f"Failed to fetch users by section: {e}"})
 def get_users_by_section_optimized(section_name):
-    """
-    Get users for a specific section with optimized caching.
-    Cache timeout: 30 minutes
-    """
-    cache_key = f'users:section:{section_name}:detailed'
-    
-    # Try to get from cache first
-    cached_users = cache.get(cache_key)
-    if cached_users is not None:
-        logger.info("Retrieved users by section from cache for %s", section_name)
-        return cached_users
-    
-    # Handle "Unassigned" section case
     if section_name == "Unassigned":
         query = """
         SELECT u.name, 
@@ -702,23 +517,9 @@ def get_users_by_section_optimized(section_name):
         """
         params = {"section_name": section_name}
     
-    try:
-        result = execute_readonly_query(query, params)
-        users = [{"name": row[0], "role": row[1]} for row in result]
-        
-        # Cache the results
-        cache.set(cache_key, users, timeout=1800)  # 30 minutes
-        logger.info("Cached users by section for %s", section_name)
-        
-        return users
-    except SQLAlchemyError as e:
-        logger.error("Failed to fetch users by section %s: %s", section_name, e)
-        error_data = {"error": f"Failed to fetch users by section: {e}"}
+    result = execute_readonly_query(query, params)
+    return [{"name": row[0], "role": row[1]} for row in result]
 
-        # Cache error for short time
-        cache.set(cache_key, error_data, timeout=60)  # 1 minute
-
-        return error_data
 
 # Update the clear_user_cache function to include new cache keys
 def clear_user_cache():

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import urllib.parse
 from datetime import datetime, timedelta
 from collections import defaultdict
 from functools import lru_cache
@@ -9,7 +11,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from redis.exceptions import RedisError
 
 from backend.globals import db, cache
-from backend.bcssm_backend.cache_utils import cached_result
+from backend.bcssm_backend.cache_utils import cached_result, get_ttl_registry
 from backend.bcssm_backend.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -546,3 +548,74 @@ def clear_user_cache():
         logger.info("Cleared user-related caches")
     except RedisError as e:
         logger.warning("Failed to clear user caches: %s", e)
+
+
+def _fmt_ttl(ttl: int) -> str:
+    if ttl >= 3600:
+        hours = ttl // 3600
+        return f"{hours} hour{'s' if hours != 1 else ''}"
+    if ttl >= 60:
+        minutes = ttl // 60
+        return f"{minutes} minute{'s' if minutes != 1 else ''}"
+    return f"{ttl} second{'s' if ttl != 1 else ''}"
+
+
+def _redact_redis_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or 'localhost'
+    port = parsed.port or 6379
+    return f"{host}:{port}"
+
+
+def get_cache_status() -> dict:
+    test_key = 'status_test'
+    cache.set(test_key, 'working', timeout=10)
+    test_result = cache.get(test_key)
+    cache.delete(test_key)
+    return {
+        "status": "healthy" if test_result == 'working' else "unhealthy",
+        "redis_url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379')),
+        "default_timeout": 300,
+        "test_result": test_result,
+        "cache_type": "RedisCache",
+        "available_operations": {
+            "clear_users": "/api/admin/cache/clear (POST with type: users)",
+            "clear_duties": "/api/admin/cache/clear (POST with type: duties)",
+            "clear_feedback": "/api/admin/cache/clear (POST with type: feedback)",
+            "clear_all": "/api/admin/cache/clear (POST with type: all)"
+        }
+    }
+
+
+def get_cache_info() -> dict:
+    return {
+        "cache_config": {
+            "type": "RedisCache",
+            "url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379')),
+            "default_timeout": 300
+        },
+        "cached_functions": {
+            name: _fmt_ttl(ttl) for name, ttl in get_ttl_registry().items()
+        },
+        "management_endpoints": {
+            "status": "GET /api/admin/cache/status",
+            "clear": "POST /api/admin/cache/clear",
+            "info": "GET /api/admin/cache/info"
+        }
+    }
+
+
+def get_health_status() -> dict:
+    cache.set('health_test', 'ok', timeout=10)
+    cache_ok = cache.get('health_test') == 'ok'
+    cache.delete('health_test')
+    health = {
+        "status": "healthy",
+        "database": "connected",
+        "cache": "healthy" if cache_ok else "unhealthy",
+        "environment": os.getenv('FLASK_ENV', 'development'),
+        "redis_url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379'))
+    }
+    if not cache_ok:
+        health["status"] = "degraded"
+    return health

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -367,6 +367,7 @@ def save_devos_feedback(section_name: str, date_str: str, new_feedback: str, edi
     })
     if not rows:
         raise ValidationError("Section not found")
+    clear_feedback_cache()
 
 
 def clear_duty_cache():

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -12,7 +12,7 @@ from redis.exceptions import RedisError
 
 from backend.globals import db, cache
 from backend.bcssm_backend.cache_utils import cached_result, get_ttl_registry
-from backend.bcssm_backend.exceptions import ValidationError
+from backend.bcssm_backend.exceptions import ValidationError, CacheError
 
 logger = logging.getLogger(__name__)
 
@@ -568,10 +568,13 @@ def _redact_redis_url(url: str) -> str:
 
 
 def get_cache_status() -> dict:
-    test_key = 'status_test'
-    cache.set(test_key, 'working', timeout=10)
-    test_result = cache.get(test_key)
-    cache.delete(test_key)
+    test_key = 'status:test'
+    try:
+        cache.set(test_key, 'working', timeout=10)
+        test_result = cache.get(test_key)
+        cache.delete(test_key)
+    except Exception as e:
+        raise CacheError(f"Cache probe failed: {e}") from e
     return {
         "status": "healthy" if test_result == 'working' else "unhealthy",
         "redis_url": _redact_redis_url(os.getenv('REDIS_URL', 'redis://localhost:6379')),
@@ -606,9 +609,12 @@ def get_cache_info() -> dict:
 
 
 def get_health_status() -> dict:
-    cache.set('health_test', 'ok', timeout=10)
-    cache_ok = cache.get('health_test') == 'ok'
-    cache.delete('health_test')
+    try:
+        cache.set('health:test', 'ok', timeout=10)
+        cache_ok = cache.get('health:test') == 'ok'
+        cache.delete('health:test')
+    except Exception as e:
+        raise CacheError(f"Cache probe failed: {e}") from e
     health = {
         "status": "healthy",
         "database": "connected",

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,0 +1,156 @@
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+from backend.bcssm_backend.routes.admin import _fmt_ttl, _redact_redis_url
+from backend.bcssm_backend.routes.system import _redact_redis_url as _sys_redact_redis_url
+from backend.bcssm_backend import create_app
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    for var in ("user", "password", "host", "port", "database"):
+        monkeypatch.setenv(var, "test")
+    monkeypatch.setenv("FLASK_ENV", "testing")
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def mock_cache(monkeypatch):
+    fake = MagicMock()
+    fake.get.return_value = None
+    fake.set.return_value = True
+    fake.delete.return_value = True
+    fake.clear.return_value = True
+    monkeypatch.setattr("backend.bcssm_backend.routes.admin.cache", fake)
+    monkeypatch.setattr("backend.bcssm_backend.routes.system.cache", fake)
+    monkeypatch.setattr("backend.bcssm_backend.utils.cache", fake)
+    return fake
+
+
+# ─── _fmt_ttl: singular / plural ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("ttl,expected", [
+    (1, "1 second"),
+    (30, "30 seconds"),
+    (59, "59 seconds"),
+    (60, "1 minute"),
+    (61, "1 minute"),      # 61 // 60 == 1
+    (120, "2 minutes"),
+    (3599, "59 minutes"),
+    (3600, "1 hour"),
+    (3601, "1 hour"),      # 3601 // 3600 == 1
+    (7200, "2 hours"),
+])
+def test_fmt_ttl(ttl, expected):
+    assert _fmt_ttl(ttl) == expected
+
+
+# ─── _redact_redis_url: credentials stripped ─────────────────────────────────
+
+@pytest.mark.parametrize("url,expected", [
+    ("redis://localhost:6379", "localhost:6379"),
+    ("redis://redis:6379", "redis:6379"),
+    ("redis://user:secret@redis.example.com:6379", "redis.example.com:6379"),
+    ("redis://:password@10.0.0.1:6380", "10.0.0.1:6380"),
+])
+def test_redact_redis_url_admin(url, expected):
+    assert _redact_redis_url(url) == expected
+
+
+def test_redact_redis_url_system(url="redis://user:secret@host:6379"):
+    assert _sys_redact_redis_url(url) == "host:6379"
+
+
+# ─── /api/admin/cache/status: URL is redacted ────────────────────────────────
+
+def test_cache_status_does_not_expose_credentials(client, mock_cache, monkeypatch):
+    mock_cache.get.return_value = "working"
+    monkeypatch.setenv("REDIS_URL", "redis://svcacct:s3cret99@redis.prod.internal:6379")
+
+    resp = client.get("/api/admin/cache/status")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    body = str(data)
+    assert "s3cret99" not in body
+    assert "svcacct" not in body
+    assert "redis_url" in data
+    assert data["redis_url"] == "redis.prod.internal:6379"
+
+
+# ─── /api/admin/cache/info: URL is redacted ──────────────────────────────────
+
+def test_cache_info_does_not_expose_credentials(client, monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://svcacct:xpassword99@cache.host:6379")
+
+    resp = client.get("/api/admin/cache/info")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    body = str(data)
+    assert "xpassword99" not in body
+    assert "svcacct" not in body
+    assert data["cache_config"]["url"] == "cache.host:6379"
+
+
+# ─── /api/health: URL is redacted ────────────────────────────────────────────
+
+def test_health_does_not_expose_credentials(client, mock_cache, monkeypatch):
+    mock_cache.get.return_value = "ok"
+    monkeypatch.setenv("REDIS_URL", "redis://ops:topsecret99@redis-prod:6379")
+
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    body = str(data)
+    assert "topsecret99" not in body
+    assert data["redis_url"] == "redis-prod:6379"
+
+
+# ─── Path traversal: commonpath guard ────────────────────────────────────────
+
+def test_path_traversal_sibling_folder_blocked(app, client, tmp_path, monkeypatch):
+    # Set up a real static folder and a sibling that must not be accessible.
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<!doctype html><html></html>")
+
+    sibling_dir = tmp_path / "static_backup"
+    sibling_dir.mkdir()
+    secret = sibling_dir / "secret.txt"
+    secret.write_text("TOP SECRET")
+
+    monkeypatch.setattr(app, "static_folder", str(static_dir))
+
+    with app.test_client() as c:
+        # A path that resolves outside static_dir via the sibling
+        resp = c.get("/../static_backup/secret.txt")
+        # Must serve index.html, not the secret file
+        assert resp.status_code == 200
+        assert b"TOP SECRET" not in resp.data
+
+
+def test_path_traversal_dot_dot_blocked(app, tmp_path, monkeypatch):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<!doctype html><html></html>")
+
+    parent_secret = tmp_path / "credentials.txt"
+    parent_secret.write_text("SENSITIVE")
+
+    monkeypatch.setattr(app, "static_folder", str(static_dir))
+
+    with app.test_client() as c:
+        resp = c.get("/../../credentials.txt")
+        assert resp.status_code == 200
+        assert b"SENSITIVE" not in resp.data

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -2,8 +2,7 @@ import os
 import pytest
 from unittest.mock import MagicMock, patch
 
-from backend.bcssm_backend.routes.admin import _fmt_ttl, _redact_redis_url
-from backend.bcssm_backend.routes.system import _redact_redis_url as _sys_redact_redis_url
+from backend.bcssm_backend.utils import _fmt_ttl, _redact_redis_url
 from backend.bcssm_backend import create_app
 
 
@@ -33,8 +32,6 @@ def mock_cache(monkeypatch):
     fake.set.return_value = True
     fake.delete.return_value = True
     fake.clear.return_value = True
-    monkeypatch.setattr("backend.bcssm_backend.routes.admin.cache", fake)
-    monkeypatch.setattr("backend.bcssm_backend.routes.system.cache", fake)
     monkeypatch.setattr("backend.bcssm_backend.utils.cache", fake)
     return fake
 
@@ -70,7 +67,7 @@ def test_redact_redis_url_admin(url, expected):
 
 
 def test_redact_redis_url_system(url="redis://user:secret@host:6379"):
-    assert _sys_redact_redis_url(url) == "host:6379"
+    assert _redact_redis_url(url) == "host:6379"
 
 
 # ─── /api/admin/cache/status: URL is redacted ────────────────────────────────

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -15,6 +15,7 @@ from backend.bcssm_backend.exceptions import (
     BaseError, DatabaseError, CacheError, ValidationError,
     AuthenticationError, NotFoundError,
 )
+from backend.bcssm_backend.routes.admin import _fmt_ttl
 
 
 @pytest.fixture(scope="function")
@@ -696,3 +697,24 @@ def test_api_sections_error_dict_returns_500(mock_get_all_sections, mock_db_cach
     assert response.status_code == 500
     data = response.get_json()
     assert data["error"] == "Failed to fetch sections"
+
+
+# ─── _fmt_ttl unit tests ───────────────────────────────────────────────────────
+
+def test_fmt_ttl_seconds():
+    assert _fmt_ttl(30) == "30 seconds"
+    assert _fmt_ttl(1) == "1 seconds"
+    assert _fmt_ttl(59) == "59 seconds"
+
+
+def test_fmt_ttl_minutes():
+    assert _fmt_ttl(60) == "1 minutes"
+    assert _fmt_ttl(120) == "2 minutes"
+    assert _fmt_ttl(900) == "15 minutes"
+    assert _fmt_ttl(3599) == "59 minutes"
+
+
+def test_fmt_ttl_hours():
+    assert _fmt_ttl(3600) == "1 hour"
+    assert _fmt_ttl(7200) == "2 hours"
+    assert _fmt_ttl(7800) == "2 hours"

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -401,7 +401,7 @@ def test_cache_status_endpoint(mock_db_cache, clean_env):
     assert data["cache_type"] == "RedisCache"
     assert data["default_timeout"] == 300
     assert "available_operations" in data
-    assert data["redis_url"] == "redis://localhost:6379"
+    assert data["redis_url"] == "localhost:6379"
 
     # Verify the cache was tested properly
     mock_cache.set.assert_called_with('status_test', 'working', timeout=10)
@@ -703,12 +703,12 @@ def test_api_sections_error_dict_returns_500(mock_get_all_sections, mock_db_cach
 
 def test_fmt_ttl_seconds():
     assert _fmt_ttl(30) == "30 seconds"
-    assert _fmt_ttl(1) == "1 seconds"
+    assert _fmt_ttl(1) == "1 second"
     assert _fmt_ttl(59) == "59 seconds"
 
 
 def test_fmt_ttl_minutes():
-    assert _fmt_ttl(60) == "1 minutes"
+    assert _fmt_ttl(60) == "1 minute"
     assert _fmt_ttl(120) == "2 minutes"
     assert _fmt_ttl(900) == "15 minutes"
     assert _fmt_ttl(3599) == "59 minutes"

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -403,9 +403,9 @@ def test_cache_status_endpoint(mock_db_cache, clean_env):
     assert data["redis_url"] == "localhost:6379"
 
     # Verify the cache was tested properly
-    mock_cache.set.assert_called_with('status_test', 'working', timeout=10)
-    mock_cache.get.assert_called_with('status_test')
-    mock_cache.delete.assert_called_with('status_test')
+    mock_cache.set.assert_called_with('status:test', 'working', timeout=10)
+    mock_cache.get.assert_called_with('status:test')
+    mock_cache.delete.assert_called_with('status:test')
 
 def test_cache_status_endpoint_exception(mock_db_cache, clean_env):
     """Test cache status endpoint when cache throws exception"""

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -29,19 +29,20 @@ def clean_env():
 @pytest.fixture
 def mock_db_cache():
     """Fixture to mock database and cache."""
-    with patch('backend.bcssm_backend.db') as mock_db, patch('backend.bcssm_backend.cache') as mock_cache:
+    fake_cache = MagicMock()
+    fake_cache.init_app = MagicMock()
+    fake_cache.set = MagicMock(return_value=True)
+    fake_cache.get = MagicMock()
+    fake_cache.delete = MagicMock(return_value=True)
+    fake_cache.clear = MagicMock(return_value=True)
+    fake_cache.cached = lambda *args, **kwargs: (lambda f: f)
+
+    with patch('backend.bcssm_backend.db') as mock_db, \
+         patch('backend.bcssm_backend.cache', fake_cache), \
+         patch('backend.bcssm_backend.routes.admin.cache', fake_cache), \
+         patch('backend.bcssm_backend.routes.system.cache', fake_cache):
         mock_db.init_app = MagicMock()
-        mock_cache.init_app = MagicMock()
-
-        # Mock cache operations for the new admin endpoints
-        mock_cache.set = MagicMock(return_value=True)
-        mock_cache.get = MagicMock()  # Will be configured per test
-        mock_cache.delete = MagicMock(return_value=True)
-        mock_cache.clear = MagicMock(return_value=True)
-
-        # Make cache.cached a no-op decorator to avoid MagicMock __name__ errors
-        mock_cache.cached = lambda *args, **kwargs: (lambda f: f)
-        yield mock_db, mock_cache
+        yield mock_db, fake_cache
 
 
 def test_create_app_with_valid_env_vars(clean_env, mock_db_cache):
@@ -118,7 +119,7 @@ def test_create_app_config(clean_env, mock_db_cache, monkeypatch, env, expected_
     mock_cache.init_app.assert_called_once_with(app)
 
 # Test that /api/sections returns data (removed caching decorator since it's internal now)
-@patch('backend.bcssm_backend.get_all_sections')
+@patch('backend.bcssm_backend.routes.system.get_all_sections')
 def test_api_sections_returns_data(mock_get_all_sections, mock_db_cache, clean_env):
     """Test /api/sections endpoint returns data from get_all_sections"""
     mock_get_all_sections.return_value = [{"id": "123", "name": "Minors"}, {"id": "456", "name": "Majors"}]
@@ -212,7 +213,7 @@ def test_health_check_endpoint_exception(mock_db_cache, clean_env):
     assert "Health check failed" in data["error"]
 
 # NEW: Test cache management endpoints
-@patch('backend.bcssm_backend.clear_user_cache')
+@patch('backend.bcssm_backend.routes.admin.clear_user_cache')
 def test_clear_cache_users(mock_clear_user_cache, mock_db_cache, clean_env):
     """Test POST /api/admin/cache/clear with type=users"""
     os.environ['FLASK_ENV'] = 'testing'
@@ -237,7 +238,7 @@ def test_clear_cache_users(mock_clear_user_cache, mock_db_cache, clean_env):
 
     mock_clear_user_cache.assert_called_once()
 
-@patch('backend.bcssm_backend.clear_duty_cache')
+@patch('backend.bcssm_backend.routes.admin.clear_duty_cache')
 def test_clear_cache_duties(mock_clear_duty_cache, mock_db_cache, clean_env):
     """Test POST /api/admin/cache/clear with type=duties"""
     os.environ['FLASK_ENV'] = 'testing'
@@ -261,7 +262,7 @@ def test_clear_cache_duties(mock_clear_duty_cache, mock_db_cache, clean_env):
 
     mock_clear_duty_cache.assert_called_once()
 
-@patch('backend.bcssm_backend.clear_feedback_cache')
+@patch('backend.bcssm_backend.routes.admin.clear_feedback_cache')
 def test_clear_cache_feedback(mock_clear_feedback_cache, mock_db_cache, clean_env):
     """Test POST /api/admin/cache/clear with type=feedback"""
     os.environ['FLASK_ENV'] = 'testing'
@@ -284,7 +285,7 @@ def test_clear_cache_feedback(mock_clear_feedback_cache, mock_db_cache, clean_en
 
     mock_clear_feedback_cache.assert_called_once()
 
-@patch('backend.bcssm_backend.clear_all_cache')
+@patch('backend.bcssm_backend.routes.admin.clear_all_cache')
 def test_clear_cache_all(mock_clear_all_cache, mock_db_cache, clean_env):
     """Test POST /api/admin/cache/clear with type=all"""
     os.environ['FLASK_ENV'] = 'testing'
@@ -340,7 +341,7 @@ def test_clear_cache_no_json(mock_db_cache, clean_env):
     app = create_app()
     client = app.test_client()
 
-    with patch('backend.bcssm_backend.clear_all_cache') as mock_clear_all:
+    with patch('backend.bcssm_backend.routes.admin.clear_all_cache') as mock_clear_all:
         response = client.post('/api/admin/cache/clear')
 
         assert response.status_code == 200
@@ -350,7 +351,7 @@ def test_clear_cache_no_json(mock_db_cache, clean_env):
 
         mock_clear_all.assert_called_once()
 
-@patch('backend.bcssm_backend.clear_user_cache')
+@patch('backend.bcssm_backend.routes.admin.clear_user_cache')
 def test_clear_cache_exception_handling(mock_clear_user_cache, mock_db_cache, clean_env):
     """Test cache clear endpoint handles exceptions properly"""
     os.environ['FLASK_ENV'] = 'testing'
@@ -474,7 +475,7 @@ def test_serve_react_for_prefix_routes(mock_load_dotenv, monkeypatch, mock_db_ca
         app.send_static_file.assert_called_with("index.html")
         assert response.get_data(as_text=True) == "served index.html via send_static_file"
 
-@patch('backend.bcssm_backend.send_from_directory')
+@patch('backend.bcssm_backend.routes.system.send_from_directory')
 @patch('backend.bcssm_backend.load_dotenv')
 def test_directory_traversal_fallback(mock_load_dotenv, mock_send, monkeypatch, mock_db_cache, clean_env):
     """Test that directory traversal attempts fallback to index.html via send_from_directory."""
@@ -496,7 +497,7 @@ def test_directory_traversal_fallback(mock_load_dotenv, mock_send, monkeypatch, 
     mock_send.assert_called_once_with(app.static_folder, "index.html")
     assert response.get_data(as_text=True) == "served index.html via send_from_directory"
 
-@patch('backend.bcssm_backend.send_from_directory')
+@patch('backend.bcssm_backend.routes.system.send_from_directory')
 @patch('backend.bcssm_backend.load_dotenv')
 def test_serve_existing_static_file_branch(mock_load_dotenv, mock_send, monkeypatch, mock_db_cache, clean_env):
     """Test that existing static files are served via send_from_directory."""
@@ -676,7 +677,7 @@ def test_global_handler_http_exception_passthrough(error_handler_app):
     assert resp.status_code == 403
 
 
-@patch('backend.bcssm_backend.get_all_sections')
+@patch('backend.bcssm_backend.routes.system.get_all_sections')
 def test_api_sections_error_dict_returns_500(mock_get_all_sections, mock_db_cache, clean_env):
     """Test /api/sections returns 500 when get_all_sections returns an error dict."""
     mock_get_all_sections.return_value = {"error": "DB unavailable"}

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -15,7 +15,7 @@ from backend.bcssm_backend.exceptions import (
     BaseError, DatabaseError, CacheError, ValidationError,
     AuthenticationError, NotFoundError,
 )
-from backend.bcssm_backend.routes.admin import _fmt_ttl
+from backend.bcssm_backend.utils import _fmt_ttl
 
 
 @pytest.fixture(scope="function")
@@ -40,8 +40,7 @@ def mock_db_cache():
 
     with patch('backend.bcssm_backend.db') as mock_db, \
          patch('backend.bcssm_backend.cache', fake_cache), \
-         patch('backend.bcssm_backend.routes.admin.cache', fake_cache), \
-         patch('backend.bcssm_backend.routes.system.cache', fake_cache):
+         patch('backend.bcssm_backend.utils.cache', fake_cache):
         mock_db.init_app = MagicMock()
         yield mock_db, fake_cache
 

--- a/backend/tests/test_cache_utils.py
+++ b/backend/tests/test_cache_utils.py
@@ -122,6 +122,19 @@ def test_on_error_list_returns_independent_copy_each_call():
     assert result2 == [], "Mutation of first fallback should not affect subsequent calls"
 
 
+def test_on_error_nested_mutable_returns_independent_copy_each_call():
+    fake_cache = _make_cache()
+
+    @cached_result('key:nestedmut', 300, on_error={"data": []}, cache=fake_cache)
+    def fn():
+        raise SQLAlchemyError("oops")
+
+    result1 = fn()
+    result1["data"].append('mutation')
+    result2 = fn()
+    assert result2["data"] == [], "Mutation of nested list should not affect subsequent calls"
+
+
 # ─── cache backend failure resilience ────────────────────────────────────────
 
 def test_cache_read_failure_treated_as_miss():

--- a/backend/tests/test_cache_utils.py
+++ b/backend/tests/test_cache_utils.py
@@ -122,6 +122,47 @@ def test_on_error_list_returns_independent_copy_each_call():
     assert result2 == [], "Mutation of first fallback should not affect subsequent calls"
 
 
+# ─── cache backend failure resilience ────────────────────────────────────────
+
+def test_cache_read_failure_treated_as_miss():
+    fake_cache = _make_cache()
+    fake_cache.get.side_effect = Exception("Redis down")
+    calls = []
+
+    @cached_result('key:test', 300, cache=fake_cache)
+    def fn():
+        calls.append(1)
+        return 'result'
+
+    result = fn()
+    assert result == 'result'
+    assert calls == [1]
+
+
+def test_cache_write_failure_still_returns_result():
+    fake_cache = _make_cache()
+    fake_cache.set.side_effect = Exception("Redis write failed")
+
+    @cached_result('key:test', 300, cache=fake_cache)
+    def fn():
+        return 'result'
+
+    result = fn()
+    assert result == 'result'
+
+
+def test_cache_error_fallback_write_failure_still_returns_fallback():
+    fake_cache = _make_cache()
+    fake_cache.set.side_effect = Exception("Redis write failed")
+
+    @cached_result('key:err', 300, error_ttl=60, on_error='fallback', cache=fake_cache)
+    def fn():
+        raise SQLAlchemyError("db down")
+
+    result = fn()
+    assert result == 'fallback'
+
+
 # ─── TTL registry ─────────────────────────────────────────────────────────────
 
 def test_ttl_registry_records_decorated_functions():

--- a/backend/tests/test_cache_utils.py
+++ b/backend/tests/test_cache_utils.py
@@ -1,0 +1,121 @@
+import pytest
+from unittest.mock import MagicMock
+from sqlalchemy.exc import SQLAlchemyError
+from backend.bcssm_backend.cache_utils import cached_result, get_ttl_registry
+
+
+def _make_cache():
+    c = MagicMock()
+    c.get.return_value = None
+    c.set.return_value = True
+    return c
+
+
+# ─── cached_result: basic caching ────────────────────────────────────────────
+
+def test_cache_miss_calls_function_and_stores_result():
+    fake_cache = _make_cache()
+
+    @cached_result('key:test', 300, cache=fake_cache)
+    def fn():
+        return [1, 2, 3]
+
+    result = fn()
+    assert result == [1, 2, 3]
+    fake_cache.get.assert_called_once_with('key:test')
+    fake_cache.set.assert_called_once_with('key:test', [1, 2, 3], timeout=300)
+
+
+def test_cache_hit_returns_cached_value_without_calling_function():
+    fake_cache = _make_cache()
+    fake_cache.get.return_value = 'cached'
+    calls = []
+
+    @cached_result('key:test', 300, cache=fake_cache)
+    def fn():
+        calls.append(1)
+        return 'fresh'
+
+    result = fn()
+    assert result == 'cached'
+    assert calls == []
+    fake_cache.set.assert_not_called()
+
+
+def test_dynamic_key_fn_receives_function_args():
+    fake_cache = _make_cache()
+
+    @cached_result(lambda x: f'key:{x}', 60, cache=fake_cache)
+    def fn(x):
+        return x * 2
+
+    fn('hello')
+    fake_cache.get.assert_called_once_with('key:hello')
+    fake_cache.set.assert_called_once_with('key:hello', 'hellohello', timeout=60)
+
+
+# ─── error handling: on_error=_RAISE (default) ───────────────────────────────
+
+def test_default_on_error_reraises_sqlalchemy_error():
+    fake_cache = _make_cache()
+
+    @cached_result('key:err', 300, cache=fake_cache)
+    def fn():
+        raise SQLAlchemyError("db down")
+
+    with pytest.raises(SQLAlchemyError):
+        fn()
+    fake_cache.set.assert_not_called()
+
+
+# ─── error handling: on_error with error_ttl ─────────────────────────────────
+
+def test_on_error_value_returned_and_cached():
+    fake_cache = _make_cache()
+
+    @cached_result('key:err', 300, error_ttl=60, on_error=[], cache=fake_cache)
+    def fn():
+        raise SQLAlchemyError("oops")
+
+    result = fn()
+    assert result == []
+    fake_cache.set.assert_called_once_with('key:err', [], timeout=60)
+
+
+def test_on_error_callable_receives_exception():
+    fake_cache = _make_cache()
+
+    @cached_result('key:err', 300, error_ttl=60,
+                   on_error=lambda e: {"error": str(e)}, cache=fake_cache)
+    def fn():
+        raise SQLAlchemyError("msg")
+
+    result = fn()
+    assert "msg" in result["error"]
+    fake_cache.set.assert_called_once()
+
+
+def test_on_error_without_error_ttl_returns_fallback_but_does_not_cache():
+    fake_cache = _make_cache()
+
+    @cached_result('key:err', 300, on_error=[], cache=fake_cache)
+    def fn():
+        raise SQLAlchemyError("oops")
+
+    result = fn()
+    assert result == []
+    fake_cache.set.assert_not_called()
+
+
+# ─── TTL registry ─────────────────────────────────────────────────────────────
+
+def test_ttl_registry_records_decorated_functions():
+    fake_cache = _make_cache()
+
+    @cached_result('key:reg', 999, cache=fake_cache)
+    def my_registered_fn():
+        return None
+
+    registry = get_ttl_registry()
+    assert 'my_registered_fn' in registry
+    assert registry['my_registered_fn'] == 999

--- a/backend/tests/test_cache_utils.py
+++ b/backend/tests/test_cache_utils.py
@@ -107,6 +107,21 @@ def test_on_error_without_error_ttl_returns_fallback_but_does_not_cache():
     fake_cache.set.assert_not_called()
 
 
+# ─── on_error mutable default isolation ──────────────────────────────────────
+
+def test_on_error_list_returns_independent_copy_each_call():
+    fake_cache = _make_cache()
+
+    @cached_result('key:mut', 300, on_error=[], cache=fake_cache)
+    def fn():
+        raise SQLAlchemyError("oops")
+
+    result1 = fn()
+    result1.append('mutation')
+    result2 = fn()
+    assert result2 == [], "Mutation of first fallback should not affect subsequent calls"
+
+
 # ─── TTL registry ─────────────────────────────────────────────────────────────
 
 def test_ttl_registry_records_decorated_functions():

--- a/backend/tests/test_cache_utils.py
+++ b/backend/tests/test_cache_utils.py
@@ -32,7 +32,7 @@ def test_cache_hit_returns_cached_value_without_calling_function():
     calls = []
 
     @cached_result('key:test', 300, cache=fake_cache)
-    def fn():
+    def fn():  # pragma: no cover
         calls.append(1)
         return 'fresh'
 
@@ -128,7 +128,7 @@ def test_ttl_registry_records_decorated_functions():
     fake_cache = _make_cache()
 
     @cached_result('key:reg', 999, cache=fake_cache)
-    def my_registered_fn():
+    def my_registered_fn():  # pragma: no cover
         return None
 
     registry = get_ttl_registry()

--- a/backend/tests/test_devos_feedback.py
+++ b/backend/tests/test_devos_feedback.py
@@ -1,10 +1,7 @@
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 from backend.bcssm_backend import create_app
-from backend.bcssm_backend.routes.devos_feedback import (
-    get_feedback_by_date,
-    get_user_info,
-)
+from backend.bcssm_backend.utils import get_feedback_by_date, get_user_info
 from urllib.parse import quote
 from unittest.mock import MagicMock
 
@@ -27,7 +24,7 @@ def client(app):
 def mock_execute_query(monkeypatch):
     mock_exec = MagicMock()
     monkeypatch.setattr(
-        "backend.bcssm_backend.routes.devos_feedback.execute_query",
+        "backend.bcssm_backend.utils.execute_query",
         mock_exec
     )
     monkeypatch.setattr(

--- a/backend/tests/test_devos_feedback.py
+++ b/backend/tests/test_devos_feedback.py
@@ -19,18 +19,14 @@ def app(monkeypatch):
 def client(app):
     return app.test_client()
 
-# ─── 2) Patch execute_query in devos_feedback and auth ──────────────────────────
+# ─── 2) Patch execute_query and execute_readonly_query ──────────────────────────
 @pytest.fixture(autouse=True)
 def mock_execute_query(monkeypatch):
     mock_exec = MagicMock()
-    monkeypatch.setattr(
-        "backend.bcssm_backend.utils.execute_query",
-        mock_exec
-    )
-    monkeypatch.setattr(
-        "backend.bcssm_backend.auth.execute_query",
-        mock_exec
-    )
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    monkeypatch.setattr("backend.bcssm_backend.auth.execute_query", mock_exec)
+    # get_feedback_by_date and get_user_info now use execute_readonly_query
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_readonly_query", mock_exec)
     return mock_exec
 
 # ─── 3) Unit tests for get_feedback_by_date ──────────────────────────────────────
@@ -168,19 +164,16 @@ def test_edit_unauthenticated(client):
 
 def test_edit_authenticated_via_query_param(client, mock_execute_query):
     """Test edit with username via query parameter"""
-    # Mock user lookup and section lookup
-    calls = []
     def side_effect(query, params=None):
-        calls.append((query, params))
         if "SELECT u.id FROM users u WHERE u.name" in query:
-            return [(1,)]  # Return user ID
-        elif "SELECT id FROM sections" in query:
-            return [(5,)]  # Return section ID
-        else:
-            return None  # Upsert query
-    
+            return [(1,)]
+        # Combined INSERT...SELECT...RETURNING query from save_devos_feedback
+        if "INSERT INTO feedback" in query:
+            return [(5,)]
+        return None
+
     mock_execute_query.side_effect = side_effect
-    
+
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis&user_name=TestUser",
                        json={"feedback": "Test"})
     assert resp.status_code == 200
@@ -188,18 +181,15 @@ def test_edit_authenticated_via_query_param(client, mock_execute_query):
 
 def test_edit_authenticated_via_header(client, mock_execute_query):
     """Test edit with username via header"""
-    calls = []
     def side_effect(query, params=None):
-        calls.append((query, params))
         if "SELECT u.id FROM users u WHERE u.name" in query:
-            return [(1,)]  # Return user ID
-        elif "SELECT id FROM sections" in query:
-            return [(5,)]  # Return section ID
-        else:
-            return None  # Upsert query
-    
+            return [(1,)]
+        if "INSERT INTO feedback" in query:
+            return [(5,)]
+        return None
+
     mock_execute_query.side_effect = side_effect
-    
+
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis",
                        json={"feedback": "Test"},
                        headers={"X-Current-User": "TestUser"})
@@ -214,10 +204,9 @@ def test_edit_authenticated_via_session(client, mock_execute_query):
     calls = []
     def side_effect(query, params=None):
         calls.append((query, params))
-        if "SELECT id FROM sections" in query:
-            return [(5,)]  # Return section ID
-        else:
-            return None  # Upsert query
+        if "INSERT INTO feedback" in query:
+            return [(5,)]
+        return None
 
     mock_execute_query.side_effect = side_effect
 
@@ -227,7 +216,7 @@ def test_edit_authenticated_via_session(client, mock_execute_query):
     assert resp.get_json() == {"success": True}
     # Verify no user ID lookup was made (session user_id used directly)
     assert not any("SELECT u.id FROM users" in call[0] for call in calls)
-    # Verify the upsert was called with editor_id from session
+    # Verify the combined query was called with editor_id from session
     upsert_call = next(call for call in calls if "INSERT INTO feedback" in call[0])
     assert upsert_call[1]['editor_id'] == 1
 
@@ -239,55 +228,50 @@ def test_edit_missing_params(client):
     assert "Missing date, section, or feedback" in resp.get_json()["error"]
 
 def test_edit_section_not_found(client, mock_execute_query):
-    """Test edit when section doesn't exist"""
-    # Mock user lookup to succeed, section lookup to fail
+    """Test edit when section doesn't exist — RETURNING returns [] from the combined query"""
     def side_effect(query, params=None):
         if "SELECT u.id FROM users u WHERE u.name" in query:
-            return [(1,)]  # Return user ID
-        elif "SELECT id FROM sections" in query:
-            return []  # Section not found
-        else:
-            return None
-    
+            return [(1,)]
+        if "INSERT INTO feedback" in query:
+            return []  # Section not found: subquery matched 0 rows
+        return None
+
     mock_execute_query.side_effect = side_effect
-    
+
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis&user_name=TestUser",
                        json={"feedback": "Test"})
     assert resp.status_code == 400
     assert "Section 'Minis' not found" in resp.get_json()["error"]
 
 def test_edit_success(client, mock_execute_query):
-    """Test successful edit operation"""
+    """Test successful edit — single atomic INSERT...SELECT...RETURNING query"""
     calls = []
     def side_effect(query, params=None):
         calls.append((query, params))
         if "SELECT u.id FROM users u WHERE u.name" in query:
-            return [(1,)]  # Return user ID
-        elif "SELECT id FROM sections" in query:
-            return [(5,)]  # Return section ID
-        else:
-            return None  # Upsert query
-    
+            return [(1,)]
+        if "INSERT INTO feedback" in query:
+            return [(5,)]
+        return None
+
     mock_execute_query.side_effect = side_effect
-    
+
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis&user_name=TestUser",
                        json={"feedback": "New"})
     assert resp.status_code == 200
     assert resp.get_json() == {"success": True}
-    assert len(calls) == 3  # User lookup, section lookup, upsert
+    assert len(calls) == 2  # User lookup + combined INSERT...SELECT
     assert any("SELECT u.id FROM users u WHERE u.name" in call[0] for call in calls)
-    assert any("SELECT id FROM sections" in call[0] for call in calls)
     assert any("INSERT INTO feedback" in call[0] for call in calls)
 
 def test_edit_upsert_error(client, mock_execute_query):
-    """Test edit when upsert operation fails with SQLAlchemyError"""
+    """Test edit when the combined INSERT...SELECT query fails"""
     def side_effect(query, params=None):
         if "SELECT u.id FROM users u WHERE u.name" in query:
-            return [(1,)]  # Return user ID
-        elif "SELECT id FROM sections" in query:
-            return [(5,)]  # Return section ID
-        else:
-            raise SQLAlchemyError("oops")  # Upsert fails
+            return [(1,)]
+        if "INSERT INTO feedback" in query:
+            raise SQLAlchemyError("oops")
+        return None
 
     mock_execute_query.side_effect = side_effect
 
@@ -298,9 +282,9 @@ def test_edit_upsert_error(client, mock_execute_query):
 
 
 def test_edit_section_lookup_db_error(client, mock_execute_query):
-    """Test edit when section lookup raises SQLAlchemyError (covers lines 152-154)"""
+    """Test edit when the combined INSERT...SELECT query raises SQLAlchemyError"""
     def side_effect(query, params=None):
-        if "SELECT id FROM sections" in query:
+        if "INSERT INTO feedback" in query:
             raise SQLAlchemyError("section DB error")
         return None
 

--- a/backend/tests/test_devos_feedback.py
+++ b/backend/tests/test_devos_feedback.py
@@ -170,7 +170,7 @@ def test_edit_authenticated_via_query_param(client, mock_execute_query):
         # Combined INSERT...SELECT...RETURNING query from save_devos_feedback
         if "INSERT INTO feedback" in query:
             return [(5,)]
-        return None
+        return None  # pragma: no cover
 
     mock_execute_query.side_effect = side_effect
 
@@ -186,7 +186,7 @@ def test_edit_authenticated_via_header(client, mock_execute_query):
             return [(1,)]
         if "INSERT INTO feedback" in query:
             return [(5,)]
-        return None
+        return None  # pragma: no cover
 
     mock_execute_query.side_effect = side_effect
 
@@ -206,7 +206,7 @@ def test_edit_authenticated_via_session(client, mock_execute_query):
         calls.append((query, params))
         if "INSERT INTO feedback" in query:
             return [(5,)]
-        return None
+        return None  # pragma: no cover
 
     mock_execute_query.side_effect = side_effect
 
@@ -234,14 +234,14 @@ def test_edit_section_not_found(client, mock_execute_query):
             return [(1,)]
         if "INSERT INTO feedback" in query:
             return []  # Section not found: subquery matched 0 rows
-        return None
+        return None  # pragma: no cover
 
     mock_execute_query.side_effect = side_effect
 
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis&user_name=TestUser",
                        json={"feedback": "Test"})
     assert resp.status_code == 400
-    assert "Section 'Minis' not found" in resp.get_json()["error"]
+    assert "Section not found" in resp.get_json()["error"]
 
 def test_edit_success(client, mock_execute_query):
     """Test successful edit — single atomic INSERT...SELECT...RETURNING query"""
@@ -252,7 +252,7 @@ def test_edit_success(client, mock_execute_query):
             return [(1,)]
         if "INSERT INTO feedback" in query:
             return [(5,)]
-        return None
+        return None  # pragma: no cover
 
     mock_execute_query.side_effect = side_effect
 
@@ -271,7 +271,7 @@ def test_edit_upsert_error(client, mock_execute_query):
             return [(1,)]
         if "INSERT INTO feedback" in query:
             raise SQLAlchemyError("oops")
-        return None
+        return None  # pragma: no cover
 
     mock_execute_query.side_effect = side_effect
 
@@ -286,7 +286,7 @@ def test_edit_section_lookup_db_error(client, mock_execute_query):
     def side_effect(query, params=None):
         if "INSERT INTO feedback" in query:
             raise SQLAlchemyError("section DB error")
-        return None
+        return None  # pragma: no cover
 
     mock_execute_query.side_effect = side_effect
 
@@ -304,7 +304,7 @@ def test_get_user_id_from_request_db_error(client, mock_execute_query):
     def side_effect(query, params=None):
         if "SELECT u.id FROM users u WHERE u.name" in query:
             raise SQLAlchemyError("lookup failed")
-        return None
+        return None  # pragma: no cover
 
     mock_execute_query.side_effect = side_effect
 

--- a/backend/tests/test_devos_feedback.py
+++ b/backend/tests/test_devos_feedback.py
@@ -20,18 +20,26 @@ def client(app):
     return app.test_client()
 
 # ─── 2) Patch execute_query and execute_readonly_query ──────────────────────────
+@pytest.fixture
+def mock_write(monkeypatch):
+    m = MagicMock()
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", m)
+    monkeypatch.setattr("backend.bcssm_backend.auth.execute_query", m)
+    return m
+
+@pytest.fixture
+def mock_read(monkeypatch):
+    m = MagicMock()
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_readonly_query", m)
+    return m
+
 @pytest.fixture(autouse=True)
-def mock_execute_query(monkeypatch):
-    mock_exec = MagicMock()
-    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
-    monkeypatch.setattr("backend.bcssm_backend.auth.execute_query", mock_exec)
-    # get_feedback_by_date and get_user_info now use execute_readonly_query
-    monkeypatch.setattr("backend.bcssm_backend.utils.execute_readonly_query", mock_exec)
-    return mock_exec
+def mock_execute_query(mock_write, mock_read):
+    return mock_write, mock_read
 
 # ─── 3) Unit tests for get_feedback_by_date ──────────────────────────────────────
-def test_get_feedback_by_date_success(mock_execute_query):
-    mock_execute_query.return_value = [("Minis", "Great job"), ("Majors", None)]
+def test_get_feedback_by_date_success(mock_read):
+    mock_read.return_value = [("Minis", "Great job"), ("Majors", None)]
     result, error = get_feedback_by_date("2025-06-07")
     assert error is None
     assert result == {
@@ -39,25 +47,25 @@ def test_get_feedback_by_date_success(mock_execute_query):
         "Majors": "No feedback available"
     }
 
-def test_get_feedback_by_date_exception(mock_execute_query):
-    mock_execute_query.side_effect = SQLAlchemyError("DB fail")
+def test_get_feedback_by_date_exception(mock_read):
+    mock_read.side_effect = SQLAlchemyError("DB fail")
     result, error = get_feedback_by_date("2025-06-07")
     assert result is None
     assert error == "An error occurred while fetching feedback"
 
 # ─── 4) Unit tests for get_user_info ────────────────────────────────────────────
-def test_get_user_info_found(mock_execute_query):
-    mock_execute_query.return_value = [("Alice", "Leader", "Minis")]
+def test_get_user_info_found(mock_read):
+    mock_read.return_value = [("Alice", "Leader", "Minis")]
     info = get_user_info("Alice")
     assert info == {"name": "Alice", "role": "Leader", "section": "Minis"}
 
-def test_get_user_info_not_found(mock_execute_query):
-    mock_execute_query.return_value = []
+def test_get_user_info_not_found(mock_read):
+    mock_read.return_value = []
     info = get_user_info("Bob")
     assert info is None
 
-def test_get_user_info_exception(mock_execute_query):
-    mock_execute_query.side_effect = SQLAlchemyError("Oops")
+def test_get_user_info_exception(mock_read):
+    mock_read.side_effect = SQLAlchemyError("Oops")
     with pytest.raises(SQLAlchemyError):
         get_user_info("Alice")
 
@@ -162,7 +170,7 @@ def test_edit_unauthenticated(client):
     data = resp.get_json()
     assert "Invalid user" in data["error"]
 
-def test_edit_authenticated_via_query_param(client, mock_execute_query):
+def test_edit_authenticated_via_query_param(client, mock_write):
     """Test edit with username via query parameter"""
     def side_effect(query, params=None):
         if "SELECT u.id FROM users u WHERE u.name" in query:
@@ -172,14 +180,14 @@ def test_edit_authenticated_via_query_param(client, mock_execute_query):
             return [(5,)]
         return None  # pragma: no cover
 
-    mock_execute_query.side_effect = side_effect
+    mock_write.side_effect = side_effect
 
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis&user_name=TestUser",
                        json={"feedback": "Test"})
     assert resp.status_code == 200
     assert resp.get_json() == {"success": True}
 
-def test_edit_authenticated_via_header(client, mock_execute_query):
+def test_edit_authenticated_via_header(client, mock_write):
     """Test edit with username via header"""
     def side_effect(query, params=None):
         if "SELECT u.id FROM users u WHERE u.name" in query:
@@ -188,7 +196,7 @@ def test_edit_authenticated_via_header(client, mock_execute_query):
             return [(5,)]
         return None  # pragma: no cover
 
-    mock_execute_query.side_effect = side_effect
+    mock_write.side_effect = side_effect
 
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis",
                        json={"feedback": "Test"},
@@ -196,7 +204,7 @@ def test_edit_authenticated_via_header(client, mock_execute_query):
     assert resp.status_code == 200
     assert resp.get_json() == {"success": True}
 
-def test_edit_authenticated_via_session(client, mock_execute_query):
+def test_edit_authenticated_via_session(client, mock_write):
     """Test edit with session user_id (no username in request, falls back to session)"""
     with client.session_transaction() as sess:
         sess["user_id"] = 1
@@ -208,7 +216,7 @@ def test_edit_authenticated_via_session(client, mock_execute_query):
             return [(5,)]
         return None  # pragma: no cover
 
-    mock_execute_query.side_effect = side_effect
+    mock_write.side_effect = side_effect
 
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis",
                        json={"feedback": "Test"})
@@ -227,7 +235,7 @@ def test_edit_missing_params(client):
     assert resp.status_code == 400
     assert "Missing date, section, or feedback" in resp.get_json()["error"]
 
-def test_edit_section_not_found(client, mock_execute_query):
+def test_edit_section_not_found(client, mock_write):
     """Test edit when section doesn't exist — RETURNING returns [] from the combined query"""
     def side_effect(query, params=None):
         if "SELECT u.id FROM users u WHERE u.name" in query:
@@ -236,14 +244,14 @@ def test_edit_section_not_found(client, mock_execute_query):
             return []  # Section not found: subquery matched 0 rows
         return None  # pragma: no cover
 
-    mock_execute_query.side_effect = side_effect
+    mock_write.side_effect = side_effect
 
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis&user_name=TestUser",
                        json={"feedback": "Test"})
     assert resp.status_code == 400
     assert "Section not found" in resp.get_json()["error"]
 
-def test_edit_success(client, mock_execute_query):
+def test_edit_success(client, mock_write):
     """Test successful edit — single atomic INSERT...SELECT...RETURNING query"""
     calls = []
     def side_effect(query, params=None):
@@ -254,7 +262,7 @@ def test_edit_success(client, mock_execute_query):
             return [(5,)]
         return None  # pragma: no cover
 
-    mock_execute_query.side_effect = side_effect
+    mock_write.side_effect = side_effect
 
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis&user_name=TestUser",
                        json={"feedback": "New"})
@@ -264,7 +272,7 @@ def test_edit_success(client, mock_execute_query):
     assert any("SELECT u.id FROM users u WHERE u.name" in call[0] for call in calls)
     assert any("INSERT INTO feedback" in call[0] for call in calls)
 
-def test_edit_upsert_error(client, mock_execute_query):
+def test_edit_upsert_error(client, mock_write):
     """Test edit when the combined INSERT...SELECT query fails"""
     def side_effect(query, params=None):
         if "SELECT u.id FROM users u WHERE u.name" in query:
@@ -273,7 +281,7 @@ def test_edit_upsert_error(client, mock_execute_query):
             raise SQLAlchemyError("oops")
         return None  # pragma: no cover
 
-    mock_execute_query.side_effect = side_effect
+    mock_write.side_effect = side_effect
 
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis&user_name=TestUser",
                        json={"feedback": "X"})
@@ -281,14 +289,14 @@ def test_edit_upsert_error(client, mock_execute_query):
     assert "Internal server error" in resp.get_json()["error"]
 
 
-def test_edit_section_lookup_db_error(client, mock_execute_query):
+def test_edit_section_lookup_db_error(client, mock_write):
     """Test edit when the combined INSERT...SELECT query raises SQLAlchemyError"""
     def side_effect(query, params=None):
         if "INSERT INTO feedback" in query:
             raise SQLAlchemyError("section DB error")
         return None  # pragma: no cover
 
-    mock_execute_query.side_effect = side_effect
+    mock_write.side_effect = side_effect
 
     with client.session_transaction() as sess:
         sess['user_id'] = 1
@@ -299,14 +307,14 @@ def test_edit_section_lookup_db_error(client, mock_execute_query):
     assert "Internal server error" in resp.get_json()["error"]
 
 
-def test_get_user_id_from_request_db_error(client, mock_execute_query):
+def test_get_user_id_from_request_db_error(client, mock_write):
     """Test SQLAlchemyError during user ID lookup is caught by the route and returns 500"""
     def side_effect(query, params=None):
         if "SELECT u.id FROM users u WHERE u.name" in query:
             raise SQLAlchemyError("lookup failed")
         return None  # pragma: no cover
 
-    mock_execute_query.side_effect = side_effect
+    mock_write.side_effect = side_effect
 
     resp = client.post("/api/devos-feedback/edit?date=2025-06-07&section=Minis&user_name=TestUser",
                        json={"feedback": "X"})

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -32,16 +32,14 @@ def mock_readonly(mocker):
 def mock_cache(monkeypatch):
     """Mock the cache to avoid Redis connection during tests"""
     fake_cache = MagicMock()
-    # Configure cache.get to return None by default (cache miss)
     fake_cache.get.return_value = None
-    # Configure cache.set to return True (success)
     fake_cache.set.return_value = True
-    # Configure cache.delete to return True (success)
     fake_cache.delete.return_value = True
-    # Configure cache.clear to return True (success)
     fake_cache.clear.return_value = True
-    
+
     monkeypatch.setattr('backend.bcssm_backend.utils.cache', fake_cache)
+    # Also patch globals.cache so the cached_result decorator's lazy import gets the mock
+    monkeypatch.setattr('backend.globals.cache', fake_cache)
     return fake_cache
 
 # ─── 2) Fixture to mock db.session directly (for testing execute_query) ─────
@@ -80,19 +78,19 @@ def test_get_all_users_happy_path(mock_readonly, mock_cache):
     params = None
     assert params is None
     expected_sql = """
-    SELECT 
-        u.name, 
-        COALESCE(s.name, 'Unassigned') AS section,  
-        u.role, 
-        COALESCE(dt.name, 'No Team') AS team 
+    SELECT
+        u.name,
+        COALESCE(s.name, 'Unassigned') AS section,
+        u.role,
+        COALESCE(dt.name, 'No Team') AS team
     FROM users u
     LEFT JOIN sections s ON u.section_id = s.id
     LEFT JOIN duty_teams dt ON u.duty_team_id = dt.id
-    ORDER BY 
-        CASE 
-            WHEN POSITION(' ' IN u.name) > 0 
+    ORDER BY
+        CASE
+            WHEN POSITION(' ' IN u.name) > 0
             THEN SUBSTRING(u.name FROM POSITION(' ' IN u.name) + 1)
-            ELSE u.name 
+            ELSE u.name
         END,
         u.name;
     """
@@ -1493,11 +1491,92 @@ def test_get_current_cycle_week_real_calculation():
 def test_get_current_cycle_week_specific_monday_july_14():
     """Test specifically for Monday July 14, 2025 which should be cycle week 1"""
     test_datetime = datetime(2025, 7, 14, 12, 0, 0)  # Monday July 14, 2025 at noon
-    
+
     with patch('backend.bcssm_backend.utils.datetime', MockDateTime(test_datetime)):
         utils.get_current_cycle_week.cache_clear()
         result = utils.get_current_cycle_week()
-        
+
         # July 14, 2025 is exactly 7 days after July 7, 2025
         # (7 // 7) % 2 = 1 % 2 = 1
         assert result == 1, f"July 14, 2025 should be cycle week 1, got {result}"
+
+
+# ─── Tests for get_feedback_by_date ─────────────────────────────────────────
+
+def test_get_feedback_by_date_success(monkeypatch):
+    mock_exec = MagicMock(return_value=[("Minis", "Great job"), ("Majors", None)])
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    result, error = utils.get_feedback_by_date("2025-06-07")
+    assert error is None
+    assert result == {"Minis": "Great job", "Majors": "No feedback available"}
+
+
+def test_get_feedback_by_date_exception(monkeypatch):
+    mock_exec = MagicMock(side_effect=SQLAlchemyError("DB fail"))
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    result, error = utils.get_feedback_by_date("2025-06-07")
+    assert result is None
+    assert error == "An error occurred while fetching feedback"
+
+
+# ─── Tests for get_user_info ─────────────────────────────────────────────────
+
+def test_get_user_info_found(monkeypatch):
+    mock_exec = MagicMock(return_value=[("Alice", "Leader", "Minis")])
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    info = utils.get_user_info("Alice")
+    assert info == {"name": "Alice", "role": "Leader", "section": "Minis"}
+
+
+def test_get_user_info_not_found(monkeypatch):
+    mock_exec = MagicMock(return_value=[])
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    assert utils.get_user_info("Bob") is None
+
+
+def test_get_user_info_exception(monkeypatch):
+    mock_exec = MagicMock(side_effect=SQLAlchemyError("Oops"))
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    with pytest.raises(SQLAlchemyError):
+        utils.get_user_info("Alice")
+
+
+# ─── Tests for save_devos_feedback ───────────────────────────────────────────
+
+def test_save_devos_feedback_success(monkeypatch):
+    calls = []
+    def side_effect(query, params=None):
+        calls.append(query)
+        if "SELECT id FROM sections" in query:
+            return [(5,)]
+        return None
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", side_effect)
+    utils.save_devos_feedback("Minis", "2025-06-07", "Great session", 1)
+    assert any("SELECT id FROM sections" in q for q in calls)
+    assert any("INSERT INTO feedback" in q for q in calls)
+
+
+def test_save_devos_feedback_section_not_found(monkeypatch):
+    mock_exec = MagicMock(return_value=[])
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    with pytest.raises(ValueError, match="Section 'Unknown' not found"):
+        utils.save_devos_feedback("Unknown", "2025-06-07", "feedback", 1)
+
+
+def test_save_devos_feedback_section_lookup_db_error(monkeypatch):
+    mock_exec = MagicMock(side_effect=SQLAlchemyError("DB error"))
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    with pytest.raises(SQLAlchemyError):
+        utils.save_devos_feedback("Minis", "2025-06-07", "feedback", 1)
+
+
+def test_save_devos_feedback_upsert_db_error(monkeypatch):
+    call_count = [0]
+    def side_effect(query, params=None):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return [(5,)]
+        raise SQLAlchemyError("upsert failed")
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", side_effect)
+    with pytest.raises(SQLAlchemyError):
+        utils.save_devos_feedback("Minis", "2025-06-07", "feedback", 1)

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1578,3 +1578,22 @@ def test_save_devos_feedback_uses_single_query(monkeypatch):
     assert "INSERT INTO feedback" in query_text
     assert "FROM sections" in query_text
     assert "RETURNING" in query_text
+
+
+def test_save_devos_feedback_clears_feedback_cache_on_success(monkeypatch):
+    mock_exec = MagicMock(return_value=[(5,)])
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    mock_clear = MagicMock()
+    monkeypatch.setattr("backend.bcssm_backend.utils.clear_feedback_cache", mock_clear)
+    utils.save_devos_feedback("Minis", "2025-06-07", "Great session", 1)
+    mock_clear.assert_called_once()
+
+
+def test_save_devos_feedback_does_not_clear_cache_when_section_not_found(monkeypatch):
+    mock_exec = MagicMock(return_value=[])
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    mock_clear = MagicMock()
+    monkeypatch.setattr("backend.bcssm_backend.utils.clear_feedback_cache", mock_clear)
+    with pytest.raises(ValidationError):
+        utils.save_devos_feedback("Unknown", "2025-06-07", "feedback", 1)
+    mock_clear.assert_not_called()

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -481,14 +481,10 @@ def test_clear_user_cache(mock_cache):
         utils.clear_user_cache()
         
         # Assert
-        # Should delete specific user-related cache keys (the function deletes more than just these 2)
-        expected_calls = [
-            unittest.mock.call('users:all:list'),
-            unittest.mock.call('sections:all:list')
-        ]
-        mock_cache.delete.assert_has_calls(expected_calls, any_order=True)
-        # The function actually deletes more keys than just these 2
-        assert mock_cache.delete.call_count >= 2
+        deleted_keys = [c.args[0] for c in mock_cache.delete.call_args_list]
+        assert 'users:all:list' in deleted_keys
+        assert 'sections:all:list' in deleted_keys
+        assert 'sections:with_users:all_v6' in deleted_keys
 
 def test_clear_duty_cache(mock_cache):
     """Test clearing duty-related caches"""
@@ -1505,7 +1501,7 @@ def test_get_current_cycle_week_specific_monday_july_14():
 
 def test_get_feedback_by_date_success(monkeypatch):
     mock_exec = MagicMock(return_value=[("Minis", "Great job"), ("Majors", None)])
-    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_readonly_query", mock_exec)
     result, error = utils.get_feedback_by_date("2025-06-07")
     assert error is None
     assert result == {"Minis": "Great job", "Majors": "No feedback available"}
@@ -1513,7 +1509,7 @@ def test_get_feedback_by_date_success(monkeypatch):
 
 def test_get_feedback_by_date_exception(monkeypatch):
     mock_exec = MagicMock(side_effect=SQLAlchemyError("DB fail"))
-    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_readonly_query", mock_exec)
     result, error = utils.get_feedback_by_date("2025-06-07")
     assert result is None
     assert error == "An error occurred while fetching feedback"
@@ -1523,20 +1519,20 @@ def test_get_feedback_by_date_exception(monkeypatch):
 
 def test_get_user_info_found(monkeypatch):
     mock_exec = MagicMock(return_value=[("Alice", "Leader", "Minis")])
-    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_readonly_query", mock_exec)
     info = utils.get_user_info("Alice")
     assert info == {"name": "Alice", "role": "Leader", "section": "Minis"}
 
 
 def test_get_user_info_not_found(monkeypatch):
     mock_exec = MagicMock(return_value=[])
-    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_readonly_query", mock_exec)
     assert utils.get_user_info("Bob") is None
 
 
 def test_get_user_info_exception(monkeypatch):
     mock_exec = MagicMock(side_effect=SQLAlchemyError("Oops"))
-    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_readonly_query", mock_exec)
     with pytest.raises(SQLAlchemyError):
         utils.get_user_info("Alice")
 
@@ -1544,39 +1540,40 @@ def test_get_user_info_exception(monkeypatch):
 # ─── Tests for save_devos_feedback ───────────────────────────────────────────
 
 def test_save_devos_feedback_success(monkeypatch):
-    calls = []
-    def side_effect(query, params=None):
-        calls.append(query)
-        if "SELECT id FROM sections" in query:
-            return [(5,)]
-        return None
-    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", side_effect)
+    # Single INSERT...SELECT...RETURNING query: returns [(section_id,)] when section exists.
+    mock_exec = MagicMock(return_value=[(5,)])
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
     utils.save_devos_feedback("Minis", "2025-06-07", "Great session", 1)
-    assert any("SELECT id FROM sections" in q for q in calls)
-    assert any("INSERT INTO feedback" in q for q in calls)
+    mock_exec.assert_called_once()
+    call_params = mock_exec.call_args[0][1]
+    assert call_params['section_name'] == 'Minis'
+    assert call_params['new_feedback'] == 'Great session'
+    assert call_params['date_str'] == '2025-06-07'
+    assert call_params['editor_id'] == 1
 
 
 def test_save_devos_feedback_section_not_found(monkeypatch):
+    # RETURNING returns [] when the SELECT subquery matches no section.
     mock_exec = MagicMock(return_value=[])
     monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
     with pytest.raises(ValueError, match="Section 'Unknown' not found"):
         utils.save_devos_feedback("Unknown", "2025-06-07", "feedback", 1)
 
 
-def test_save_devos_feedback_section_lookup_db_error(monkeypatch):
+def test_save_devos_feedback_db_error(monkeypatch):
     mock_exec = MagicMock(side_effect=SQLAlchemyError("DB error"))
     monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
     with pytest.raises(SQLAlchemyError):
         utils.save_devos_feedback("Minis", "2025-06-07", "feedback", 1)
 
 
-def test_save_devos_feedback_upsert_db_error(monkeypatch):
-    call_count = [0]
-    def side_effect(query, params=None):
-        call_count[0] += 1
-        if call_count[0] == 1:
-            return [(5,)]
-        raise SQLAlchemyError("upsert failed")
-    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", side_effect)
-    with pytest.raises(SQLAlchemyError):
-        utils.save_devos_feedback("Minis", "2025-06-07", "feedback", 1)
+def test_save_devos_feedback_uses_single_query(monkeypatch):
+    # Verifies the TOCTOU-safe single-query design: exactly one execute_query call.
+    mock_exec = MagicMock(return_value=[(7,)])
+    monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
+    utils.save_devos_feedback("Seniors", "2025-06-07", "Good work", 2)
+    assert mock_exec.call_count == 1
+    query_text = mock_exec.call_args[0][0]
+    assert "INSERT INTO feedback" in query_text
+    assert "FROM sections" in query_text
+    assert "RETURNING" in query_text

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -6,6 +6,7 @@ import logging
 from sqlalchemy.exc import SQLAlchemyError
 from redis.exceptions import RedisError
 from backend.bcssm_backend import create_app, utils
+from backend.bcssm_backend.exceptions import ValidationError
 import unittest.mock
 
 # Save reference to the real function before autouse patching replaces it
@@ -1556,7 +1557,7 @@ def test_save_devos_feedback_section_not_found(monkeypatch):
     # RETURNING returns [] when the SELECT subquery matches no section.
     mock_exec = MagicMock(return_value=[])
     monkeypatch.setattr("backend.bcssm_backend.utils.execute_query", mock_exec)
-    with pytest.raises(ValueError, match="Section 'Unknown' not found"):
+    with pytest.raises(ValidationError, match="Section not found"):
         utils.save_devos_feedback("Unknown", "2025-06-07", "feedback", 1)
 
 

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -87,7 +87,10 @@ export const getCurrentUser = (): string | null => {
     }
 
     const response = await apiGet('/api/auth/validate');
-    if (!response.ok) return false;
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) return false;
+      throw new Error(`Auth check failed with status ${response.status}`);
+    }
     const data = await response.json();
 
     if (data.is_valid) {

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -75,29 +75,27 @@ export const getCurrentUser = (): string | null => {
     });
   };
   
-  // Auth validation function
+  // Auth validation function.
+  // Returns true if the server confirms the session is valid.
+  // Returns false if the server explicitly says the session is invalid.
+  // Throws on network/transport errors so callers can distinguish transient failures.
   export const validateAuth = async (): Promise<boolean> => {
     const currentUser = getCurrentUser();
-    
+
     if (!currentUser) {
       return false;
     }
-    
-    try {
-      const response = await apiGet('/api/auth/validate');
-      const data = await response.json();
-      
-      if (data.is_valid) {
-        // Update localStorage with fresh data
-        localStorage.setItem("is_logged_in", "true");
-        if (data.role) localStorage.setItem("user_role", data.role);
-        if (data.section) localStorage.setItem("user_section", data.section);
-        localStorage.setItem("is_leader", data.is_leader ? "true" : "false");
-        return true;
-      }
-    } catch (error) {
-      console.error("Auth validation failed:", error);
+
+    const response = await apiGet('/api/auth/validate');
+    const data = await response.json();
+
+    if (data.is_valid) {
+      localStorage.setItem("is_logged_in", "true");
+      if (data.role) localStorage.setItem("user_role", data.role);
+      if (data.section) localStorage.setItem("user_section", data.section);
+      localStorage.setItem("is_leader", data.is_leader ? "true" : "false");
+      return true;
     }
-    
+
     return false;
   };

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -87,6 +87,7 @@ export const getCurrentUser = (): string | null => {
     }
 
     const response = await apiGet('/api/auth/validate');
+    if (!response.ok) return false;
     const data = await response.json();
 
     if (data.is_valid) {

--- a/frontend/src/DevoFeedback.tsx
+++ b/frontend/src/DevoFeedback.tsx
@@ -91,16 +91,24 @@ const DevoFeedback: React.FC = () => {
 
   useEffect(() => {
     const fetchSections = async () => {
+      const parseSections = async (res: Response): Promise<string[]> => {
+        if (!res.ok) throw new Error(`Sections fetch failed: ${res.status}`);
+        const data: unknown = await res.json();
+        if (!Array.isArray(data) || !data.every((x) => typeof x === 'string')) {
+          throw new Error('Sections response is not a string array');
+        }
+        return data;
+      };
       try {
         const res = await apiGet('/api/sections');
-        const data: string[] = await res.json();
+        const data = await parseSections(res);
         console.log('Fetched sections:', data);
         setSections(data);
       } catch (error) {
         console.error('Error fetching sections:', error);
         try {
           const res = await apiGet('/api/sections');
-          const data: string[] = await res.json();
+          const data = await parseSections(res);
           setSections(data);
         } catch (fallbackError) {
           console.error('Fallback fetch also failed:', fallbackError);

--- a/frontend/src/DevoFeedback.tsx
+++ b/frontend/src/DevoFeedback.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { useSearchParams, Link, useNavigate } from 'react-router-dom';
+import { useSearchParams, Link } from 'react-router-dom';
 import Navbar from './Navbar';
-import { apiGet, getCurrentUser, isLoggedIn, validateAuth } from '../api';
+import { apiGet } from '../api';
+import { useRequireAuth } from './hooks/useRequireAuth';
 import "./DevoFeedback.css";
 
 type FeedbackData = {
@@ -16,6 +17,7 @@ type DevoFeedbackResponse = {
 };
 
 const DevoFeedback: React.FC = () => {
+  const { currentUser, loading: authLoading } = useRequireAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentDateStr = searchParams.get('date') || new Date().toISOString().split('T')[0];
   const [date, setDate] = useState(currentDateStr);
@@ -23,57 +25,27 @@ const DevoFeedback: React.FC = () => {
   const [sections, setSections] = useState<string[]>([]);
   const [userSection, setUserSection] = useState<string | null>(null);
   const [isLeaderState, setIsLeaderState] = useState<boolean>(false);
-  const [isLoggedInState, setIsLoggedInState] = useState<boolean>(false);
-  const [loading, setLoading] = useState<boolean>(true);
-  const navigate = useNavigate();
+  const [dataLoading, setDataLoading] = useState<boolean>(true);
   const base = import.meta.env.VITE_BASE_URL || '';
 
   useEffect(() => {
-    const initializePage = async () => {
-      // Check if user is logged in using the same method as other pages
-      if (!isLoggedIn()) {
-        console.log("No user logged in, redirecting to login");
-        navigate("/login");
-        return;
-      }
-      
-      const user = getCurrentUser();
-      console.log("Current user from localStorage:", user);
-      
-      if (!user) {
-        navigate("/login");
-        return;
-      }
-      
-      // Validate that the user is still valid
-      const isValid = await validateAuth();
-      if (!isValid) {
-        console.log("User validation failed, redirecting to login");
-        localStorage.clear();
-        navigate("/login");
-        return;
-      }
-
-      // Now fetch the feedback data
-      await fetchFeedbackData();
-    };
+    if (!currentUser) return;
 
     const fetchFeedbackData = async () => {
       try {
         const url = `/api/devos-feedback?date=${currentDateStr}`;
         console.log('Fetching devos-feedback from:', url);
-        
-        // Use apiGet which automatically includes username in header/params
+
         const res = await apiGet(url);
-        
+
         console.log('Response status:', res.status, 'Content-Type:', res.headers.get('content-type'));
         if (!res.ok) {
           throw new Error(`Network response was not ok: ${res.status}`);
         }
-        
+
         const text = await res.text();
         console.log('Raw devos-feedback response text:', text);
-        
+
         let dataParsed: DevoFeedbackResponse;
         try {
           dataParsed = JSON.parse(text);
@@ -86,47 +58,41 @@ const DevoFeedback: React.FC = () => {
           console.error('Error parsing devos-feedback JSON:', e);
           throw e;
         }
-        
+
         console.log('Parsed devos-feedback data:', dataParsed);
         setFeedback(dataParsed.feedback || {});
-        
-        // Validate that date matches YYYY-MM-DD
+
         const dateVal = typeof dataParsed.date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(dataParsed.date)
           ? dataParsed.date
           : currentDateStr;
         setDate(dateVal);
-        
-        // Set user state from devos-feedback payload
+
         if (dataParsed.user) {
           setUserSection(dataParsed.user.section);
           setIsLeaderState(dataParsed.is_leader ?? false);
-          setIsLoggedInState(true);
         }
-        
+
       } catch (error) {
         console.error('Error fetching or parsing devos-feedback:', error);
-        // Fallback to default state on error
         setFeedback({});
         setDate(currentDateStr);
       } finally {
-        setLoading(false);
+        setDataLoading(false);
       }
     };
 
-    initializePage();
-  }, [currentDateStr, navigate]);
+    fetchFeedbackData();
+  }, [currentUser, currentDateStr]);
 
   useEffect(() => {
     const fetchSections = async () => {
       try {
-        // Use apiGet for sections too (though this endpoint might not need auth)
         const res = await apiGet('/api/sections');
         const data: string[] = await res.json();
         console.log('Fetched sections:', data);
         setSections(data);
       } catch (error) {
         console.error('Error fetching sections:', error);
-        // Try fallback to regular fetch if apiGet fails for this endpoint
         try {
           const res = await fetch(`${base}/api/sections`);
           const data: string[] = await res.json();
@@ -146,7 +112,7 @@ const DevoFeedback: React.FC = () => {
     setSearchParams({ date: newDate });
   };
 
-  if (loading || !sections.length) {
+  if (authLoading || dataLoading || !sections.length) {
     return (
       <>
         <Navbar />
@@ -191,23 +157,23 @@ const DevoFeedback: React.FC = () => {
             {sections.map(section => {
               const feedbackText = feedback[section] ?? null;
               const hasContent = Boolean(feedbackText?.trim());
-              
+
               return (
                 <div className="feedback-card" key={section}>
                   <div className="feedback-card-header">
                     <h3 className="section-title">{section}</h3>
-                    {isLoggedInState && (isLeaderState || userSection === section) && (
+                    {currentUser !== null && (isLeaderState || userSection === section) && (
                       <div className="action-buttons">
                         {hasContent ? (
-                          <Link 
-                            to={`${base}/react/devos-feedback/edit?date=${date}&section=${encodeURIComponent(section)}`} 
+                          <Link
+                            to={`${base}/react/devos-feedback/edit?date=${date}&section=${encodeURIComponent(section)}`}
                             className="action-btn edit-btn"
                           >
                             ✏️ Edit
                           </Link>
                         ) : (
-                          <Link 
-                            to={`${base}/react/devos-feedback/edit?date=${date}&section=${encodeURIComponent(section)}`} 
+                          <Link
+                            to={`${base}/react/devos-feedback/edit?date=${date}&section=${encodeURIComponent(section)}`}
                             className="action-btn add-btn"
                           >
                             ➕ Add

--- a/frontend/src/DevoFeedback.tsx
+++ b/frontend/src/DevoFeedback.tsx
@@ -99,7 +99,7 @@ const DevoFeedback: React.FC = () => {
       } catch (error) {
         console.error('Error fetching sections:', error);
         try {
-          const res = await fetch(`${base}/api/sections`);
+          const res = await apiGet('/api/sections');
           const data: string[] = await res.json();
           setSections(data);
         } catch (fallbackError) {

--- a/frontend/src/DevoFeedback.tsx
+++ b/frontend/src/DevoFeedback.tsx
@@ -26,10 +26,15 @@ const DevoFeedback: React.FC = () => {
   const [userSection, setUserSection] = useState<string | null>(null);
   const [isLeaderState, setIsLeaderState] = useState<boolean>(false);
   const [dataLoading, setDataLoading] = useState<boolean>(true);
+  const [sectionsLoading, setSectionsLoading] = useState<boolean>(true);
   const base = import.meta.env.VITE_BASE_URL || '';
 
   useEffect(() => {
     if (!currentUser) return;
+    setDataLoading(true);
+    setFeedback({});
+    setUserSection(null);
+    setIsLeaderState(false);
 
     const fetchFeedbackData = async () => {
       try {
@@ -100,6 +105,8 @@ const DevoFeedback: React.FC = () => {
         } catch (fallbackError) {
           console.error('Fallback fetch also failed:', fallbackError);
         }
+      } finally {
+        setSectionsLoading(false);
       }
     };
 
@@ -112,7 +119,7 @@ const DevoFeedback: React.FC = () => {
     setSearchParams({ date: newDate });
   };
 
-  if (authLoading || dataLoading || !sections.length) {
+  if (authLoading || dataLoading || sectionsLoading) {
     return (
       <>
         <Navbar />

--- a/frontend/src/DevoFeedbackEdit.tsx
+++ b/frontend/src/DevoFeedbackEdit.tsx
@@ -20,6 +20,10 @@ const DevoFeedbackEdit: React.FC = () => {
 
   useEffect(() => {
     if (!currentUser) return;
+    setDataLoading(true);
+    setError(null);
+    setFeedback('');
+    setCharacterCount(0);
 
     if (!dateStr || !section) {
       setError('Missing date or section parameters');

--- a/frontend/src/DevoFeedbackEdit.tsx
+++ b/frontend/src/DevoFeedbackEdit.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, FormEvent } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import Navbar from './Navbar';
-import { apiGet, apiPost, getCurrentUser, isLoggedIn, validateAuth } from '../api';
+import { apiGet, apiPost } from '../api';
+import { useRequireAuth } from './hooks/useRequireAuth';
 import "./DevoFeedbackEdit.css";
 
 const DevoFeedbackEdit: React.FC = () => {
@@ -10,61 +11,32 @@ const DevoFeedbackEdit: React.FC = () => {
   const section = searchParams.get('section') || '';
   const navigate = useNavigate();
 
+  const { currentUser, loading: authLoading } = useRequireAuth();
   const [feedback, setFeedback] = useState<string>('');
-  const [loading, setLoading] = useState<boolean>(true);
+  const [dataLoading, setDataLoading] = useState<boolean>(true);
   const [saving, setSaving] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [characterCount, setCharacterCount] = useState<number>(0);
 
-  // Load existing feedback
   useEffect(() => {
-    const initializePage = async () => {
-      if (!dateStr || !section) {
-        setError('Missing date or section parameters');
-        setLoading(false);
-        return;
-      }
+    if (!currentUser) return;
 
-      // Check if user is logged in using the same method as other pages
-      if (!isLoggedIn()) {
-        console.log("No user logged in, redirecting to login");
-        navigate("/login");
-        return;
-      }
-      
-      const user = getCurrentUser();
-      console.log("Current user from localStorage:", user);
-      
-      if (!user) {
-        navigate("/login");
-        return;
-      }
-      
-      // Validate that the user is still valid
-      const isValid = await validateAuth();
-      if (!isValid) {
-        console.log("User validation failed, redirecting to login");
-        localStorage.clear();
-        navigate("/login");
-        return;
-      }
+    if (!dateStr || !section) {
+      setError('Missing date or section parameters');
+      setDataLoading(false);
+      return;
+    }
 
-      // Now load the feedback data
-      await loadFeedback();
-    };
-    
     const loadFeedback = async () => {
       try {
-        // Use apiGet which automatically includes username in header/params
         const res = await apiGet(
           `/api/devos-feedback?date=${encodeURIComponent(dateStr)}&section=${encodeURIComponent(section)}`
         );
         if (!res.ok) throw new Error(`Failed to load feedback: ${res.statusText}`);
-        
+
         const data = await res.json();
         console.log('Fetched feedback response:', data);
-        
-        // Populate the textarea with the specific section's feedback string
+
         const existingFeedback = data.feedback?.[section] ?? '';
         setFeedback(existingFeedback);
         setCharacterCount(existingFeedback.length);
@@ -72,26 +44,23 @@ const DevoFeedbackEdit: React.FC = () => {
         console.error('Error loading feedback:', err);
         setError((err as Error).message);
       } finally {
-        setLoading(false);
+        setDataLoading(false);
       }
     };
 
-    initializePage();
-  }, [dateStr, section, navigate]);
+    loadFeedback();
+  }, [currentUser, dateStr, section]);
 
-  // Handle textarea changes
   const handleFeedbackChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     setFeedback(value);
     setCharacterCount(value.length);
-    // Clear error when user starts typing
     if (error) setError(null);
   };
 
-  // Submit handler
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    
+
     if (!feedback.trim()) {
       setError('Please enter some feedback before saving');
       return;
@@ -99,19 +68,17 @@ const DevoFeedbackEdit: React.FC = () => {
 
     setSaving(true);
     setError(null);
-    
+
     try {
-      // Use apiPost which automatically includes username in header/body
       const res = await apiPost(
         `/api/devos-feedback/edit?date=${encodeURIComponent(dateStr)}&section=${encodeURIComponent(section)}`,
         { feedback }
       );
-      
+
       if (!res.ok) {
         throw new Error(`Failed to save feedback: ${res.statusText}`);
       }
-      
-      // Navigate back to the feedback page
+
       navigate(`/react/devos-feedback?date=${encodeURIComponent(dateStr)}`, { replace: true });
     } catch (err) {
       console.error('Error saving feedback:', err);
@@ -121,12 +88,10 @@ const DevoFeedbackEdit: React.FC = () => {
     }
   };
 
-  // Cancel handler
   const handleCancel = () => {
     navigate(`/react/devos-feedback?date=${encodeURIComponent(dateStr)}`);
   };
 
-  // Format date for display
   const formatDate = (dateString: string) => {
     try {
       return new Date(dateString).toLocaleDateString('en-GB', {
@@ -140,7 +105,7 @@ const DevoFeedbackEdit: React.FC = () => {
     }
   };
 
-  if (loading) {
+  if (authLoading || dataLoading) {
     return (
       <>
         <Navbar />
@@ -217,8 +182,8 @@ const DevoFeedbackEdit: React.FC = () => {
               >
                 ❌ Cancel
               </button>
-              <button 
-                type="submit" 
+              <button
+                type="submit"
                 className="save-btn"
                 disabled={saving || !feedback.trim()}
               >

--- a/frontend/src/DevoFeedbackEdit.tsx
+++ b/frontend/src/DevoFeedbackEdit.tsx
@@ -31,10 +31,13 @@ const DevoFeedbackEdit: React.FC = () => {
       return;
     }
 
+    const controller = new AbortController();
+
     const loadFeedback = async () => {
       try {
         const res = await apiGet(
-          `/api/devos-feedback?date=${encodeURIComponent(dateStr)}&section=${encodeURIComponent(section)}`
+          `/api/devos-feedback?date=${encodeURIComponent(dateStr)}&section=${encodeURIComponent(section)}`,
+          { signal: controller.signal }
         );
         if (!res.ok) throw new Error(`Failed to load feedback: ${res.statusText}`);
 
@@ -45,14 +48,16 @@ const DevoFeedbackEdit: React.FC = () => {
         setFeedback(existingFeedback);
         setCharacterCount(existingFeedback.length);
       } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
         console.error('Error loading feedback:', err);
         setError((err as Error).message);
       } finally {
-        setDataLoading(false);
+        if (!controller.signal.aborted) setDataLoading(false);
       }
     };
 
     loadFeedback();
+    return () => controller.abort();
   }, [currentUser, dateStr, section]);
 
   const handleFeedbackChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/frontend/src/DutiesPage.tsx
+++ b/frontend/src/DutiesPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import Navbar from "./Navbar";
-import { apiGet, getCurrentUser, isLoggedIn, validateAuth } from "../api";
+import { apiGet } from "../api";
+import { useRequireAuth } from "./hooks/useRequireAuth";
 import "./DutiesPage.css";
 
 type Duty = {
@@ -39,53 +39,25 @@ type ScheduleData = {
 };
 
 export default function DutiesPage() {
+  const { currentUser, loading: authLoading } = useRequireAuth();
   const [duties, setDuties] = useState<Duty[]>([]);
   const [schedule, setSchedule] = useState<ScheduleDay[]>([]);
   const [loading, setLoading] = useState(true);
   const [scheduleLoading, setScheduleLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'today' | 'schedule'>('today');
-  const navigate = useNavigate();
 
   useEffect(() => {
-    const initializePage = async () => {
-      // Check if user is logged in using the same method as Home page
-      if (!isLoggedIn()) {
-        console.log("No user logged in, redirecting to login");
-        navigate("/login");
-        return;
-      }
-      
-      const user = getCurrentUser();
-      console.log("Current user from localStorage:", user);
-      
-      if (!user) {
-        navigate("/login");
-        return;
-      }
-      
-      // Validate that the user is still valid
-      const isValid = await validateAuth();
-      if (!isValid) {
-        console.log("User validation failed, redirecting to login");
-        localStorage.clear();
-        navigate("/login");
-        return;
-      }
-
-      // Now fetch the duties data using API utilities
-      await Promise.all([fetchDuties(), fetchSchedule()]);
-    };
+    if (!currentUser) return;
 
     const fetchDuties = async () => {
       try {
-        // Use apiGet which automatically includes username in header/params
         const res = await apiGet("/api/duties/today");
         if (!res.ok) throw new Error(`Failed to fetch duties: ${res.statusText}`);
-        
+
         const data = await res.json() as ApiDuty[];
         console.log("Raw duties from API:", data);
-        
+
         const mapped: Duty[] = data.map((d) => ({
           id: d.id,
           name: d.name,
@@ -94,7 +66,7 @@ export default function DutiesPage() {
           isCurrentUser: d.is_current_user,
           teamName: d.team_name,
         }));
-        
+
         console.log("Mapped duties for UI:", mapped);
         setDuties(mapped);
       } catch (err) {
@@ -107,13 +79,12 @@ export default function DutiesPage() {
 
     const fetchSchedule = async () => {
       try {
-        // Use apiGet which automatically includes username in header/params
         const res = await apiGet("/api/duties/schedule");
         if (!res.ok) throw new Error(`Failed to fetch schedule: ${res.statusText}`);
-        
+
         const data: ScheduleData = await res.json();
         console.log("Raw schedule from API:", data);
-        
+
         setSchedule(data.schedule || []);
       } catch (err) {
         console.error("Error fetching schedule:", err);
@@ -123,8 +94,8 @@ export default function DutiesPage() {
       }
     };
 
-    initializePage();
-  }, [navigate]);
+    Promise.all([fetchDuties(), fetchSchedule()]);
+  }, [currentUser]);
 
   // Extract team number from team name (format: "Duty Team 1", "Duty Team 2", etc.)
   const getTeamNumber = (teamName?: string): string => {
@@ -160,7 +131,7 @@ export default function DutiesPage() {
     });
   };
 
-  if (loading && scheduleLoading) {
+  if (authLoading || (loading && scheduleLoading)) {
     return (
       <>
         <Navbar />
@@ -186,16 +157,16 @@ export default function DutiesPage() {
             <h1 className="duties-title">📋 Duties Dashboard</h1>
             <p className="duties-date">{getCurrentDate()}</p>
           </div>
-          
+
           {/* Tab Navigation */}
           <div className="tab-navigation">
-            <button 
+            <button
               className={`tab-button ${activeTab === 'today' ? 'active' : ''}`}
               onClick={() => setActiveTab('today')}
             >
               📅 Today's Duties
             </button>
-            <button 
+            <button
               className={`tab-button ${activeTab === 'schedule' ? 'active' : ''}`}
               onClick={() => setActiveTab('schedule')}
             >
@@ -222,7 +193,7 @@ export default function DutiesPage() {
                   <span className="section-icon">👤</span>
                   Your Duties
                 </h2>
-                
+
                 {myDuties.length > 0 ? (
                   <div className="duties-grid">
                     {myDuties.map((duty) => {
@@ -274,7 +245,7 @@ export default function DutiesPage() {
                   <span className="section-icon">👥</span>
                   Other Duties
                 </h2>
-                
+
                 {otherDuties.length > 0 ? (
                   <div className="duties-grid">
                     {otherDuties.map((duty) => {
@@ -328,7 +299,7 @@ export default function DutiesPage() {
                 <span className="section-icon">🗓️</span>
                 2-Week Duty Schedule (Starting July 5th, 2025)
               </h2>
-              
+
               {scheduleLoading ? (
                 <div className="loading-container">
                   <div className="loading-spinner"></div>
@@ -374,13 +345,13 @@ export default function DutiesPage() {
                             const dutyTeamMap: { [key: string]: string } = {};
                             if (day.duties && Array.isArray(day.duties)) {
                               day.duties.forEach(duty => {
-                                if (duty && duty.duty_name && duty.team_name && 
+                                if (duty && duty.duty_name && duty.team_name &&
                                     typeof duty.duty_name === 'string' && typeof duty.team_name === 'string') {
                                   dutyTeamMap[duty.duty_name] = duty.team_name;
                                 }
                               });
                             }
-                            
+
                             return (
                               <tr key={index} className="schedule-row">
                                 <td className="date-cell">

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,15 +1,14 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import Navbar from "./Navbar";
-import { apiGet, getCurrentUser, isLoggedIn, validateAuth } from "../api";
+import { apiGet } from "../api";
+import { useRequireAuth } from "./hooks/useRequireAuth";
 import "./Home.css";
 
 function Home() {
-  const [currentUser, setCurrentUser] = useState<string | null>(null);
+  const { currentUser, loading: authLoading } = useRequireAuth();
   const [userRole, setUserRole] = useState<string | null>(null);
   const [dutyMessage, setDutyMessage] = useState<string | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  const navigate = useNavigate();
+  const [dataLoading, setDataLoading] = useState<boolean>(true);
 
   // Check if user has access to forms based on their role
   const hasFormsAccess = (role: string | null): boolean => {
@@ -19,67 +18,38 @@ function Home() {
   };
 
   useEffect(() => {
-    const initializeApp = async () => {
-      console.log("Home component initializing...");
-      
-      // Check if user is logged in
-      if (!isLoggedIn()) {
-        console.log("No user logged in, redirecting to login");
-        navigate("/login");
-        return;
-      }
-      
-      const user = getCurrentUser();
-      console.log("Current user from localStorage:", user);
-      
-      if (!user) {
-        navigate("/login");
-        return;
-      }
-      
-      // Validate that the user is still valid
-      const isValid = await validateAuth();
-      if (!isValid) {
-        console.log("User validation failed, redirecting to login");
-        localStorage.clear(); // Clear all auth data
-        navigate("/login");
-        return;
-      }
-      
-      setCurrentUser(user);
-      
-      // Get user role from localStorage (updated by validateAuth)
+    if (!currentUser) return;
+
+    const fetchDutyInfo = async () => {
       const role = localStorage.getItem("user_role");
       setUserRole(role);
-      
-      // Fetch duty info using the new API utility
+
       try {
         console.log("Fetching duty info...");
         const response = await apiGet("/duty-teams");
-        
+
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
-        
+
         const data = await response.json();
         console.log("Duty data received:", data);
-        
+
         if (data && data.user) {
           setDutyMessage(data.duty_message);
-          setUserRole(data.role || role); // Use API role or fallback to localStorage
+          setUserRole(data.role || role);
         }
       } catch (error) {
         console.error("Error fetching duty info:", error);
-        // Don't redirect on duty fetch error - user is still valid
       } finally {
-        setLoading(false);
+        setDataLoading(false);
       }
     };
 
-    initializeApp();
-  }, [navigate]);
+    fetchDutyInfo();
+  }, [currentUser]);
 
-  if (loading) {
+  if (authLoading || dataLoading) {
     return (
       <>
         <Navbar />
@@ -115,7 +85,7 @@ function Home() {
             <p>No duty assigned today.</p>
           )}
         </div>
-        
+
         {/* Forms access for Section Leaders, Team Leaders, and Admins */}
         {hasFormsAccess(userRole) && (
           <div className="forms-section">

--- a/frontend/src/Sections.tsx
+++ b/frontend/src/Sections.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import Navbar from "./Navbar";
-import { apiGet, getCurrentUser, isLoggedIn, validateAuth } from '../api';
+import { apiGet } from '../api';
+import { useRequireAuth } from "./hooks/useRequireAuth";
 import "./Sections.css";
 
 type User = {
@@ -24,38 +24,16 @@ type SectionData = {
 };
 
 export default function UsersBySectionPage() {
+  const { currentUser, loading: authLoading } = useRequireAuth();
   const [sectionsData, setSectionsData] = useState<SectionData | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [dataLoading, setDataLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filterRole, setFilterRole] = useState<string>("all");
   const [filterWeek, setFilterWeek] = useState<string>("all");
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
 
-  const navigate = useNavigate();
-
   useEffect(() => {
-    const initializePage = async () => {
-      if (!isLoggedIn()) {
-        navigate("/login");
-        return;
-      }
-
-      const user = getCurrentUser();
-      if (!user) {
-        navigate("/login");
-        return;
-      }
-
-      const isValid = await validateAuth();
-      if (!isValid) {
-        localStorage.clear();
-        navigate("/login");
-        return;
-      }
-
-      await fetchUsersBySection();
-    };
-
+    if (!currentUser) return;
     const fetchUsersBySection = async () => {
       try {
         const timestamp = new Date().getTime();
@@ -69,12 +47,11 @@ export default function UsersBySectionPage() {
         console.error("Error fetching users by section:", err);
         setError((err as Error).message);
       } finally {
-        setLoading(false);
+        setDataLoading(false);
       }
     };
-
-    initializePage();
-  }, [navigate]);
+    fetchUsersBySection();
+  }, [currentUser]);
 
   const toggleSection = (sectionName: string) => {
     setCollapsedSections(prev => {
@@ -182,7 +159,7 @@ export default function UsersBySectionPage() {
     }
   };
 
-  if (loading) {
+  if (authLoading || dataLoading) {
     return (
       <>
         <Navbar />

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -174,10 +174,18 @@ describe('validateAuth', () => {
     await expect(validateAuth()).rejects.toThrow('Network error');
   });
 
-  it('returns false when server responds with non-ok status (e.g. 502 HTML body)', async () => {
+  it('throws when server responds with a non-auth error status (e.g. 502)', async () => {
     localStorage.setItem('currentUser', 'Dave');
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response('<html>Bad Gateway</html>', { status: 502 })
+    );
+    await expect(validateAuth()).rejects.toThrow('Auth check failed with status 502');
+  });
+
+  it('returns false when server responds with 401', async () => {
+    localStorage.setItem('currentUser', 'Dave');
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: 'Unauthorized' }), { status: 401 })
     );
     const result = await validateAuth();
     expect(result).toBe(false);

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -168,10 +168,9 @@ describe('validateAuth', () => {
     expect(result).toBe(false);
   });
 
-  it('returns false on fetch error', async () => {
+  it('throws on network/transport error', async () => {
     localStorage.setItem('currentUser', 'Dave');
     vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
-    const result = await validateAuth();
-    expect(result).toBe(false);
+    await expect(validateAuth()).rejects.toThrow('Network error');
   });
 });

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -173,4 +173,13 @@ describe('validateAuth', () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
     await expect(validateAuth()).rejects.toThrow('Network error');
   });
+
+  it('returns false when server responds with non-ok status (e.g. 502 HTML body)', async () => {
+    localStorage.setItem('currentUser', 'Dave');
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('<html>Bad Gateway</html>', { status: 502 })
+    );
+    const result = await validateAuth();
+    expect(result).toBe(false);
+  });
 });

--- a/frontend/src/__tests__/useRequireAuth.test.tsx
+++ b/frontend/src/__tests__/useRequireAuth.test.tsx
@@ -92,4 +92,64 @@ describe('useRequireAuth', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(localStorage.getItem('currentUser')).toBe('Charlie');
   });
+
+  // Finding 1: cross-tab localStorage race — server says valid but storage was cleared mid-flight
+  it('redirects to /login when localStorage is cleared while validateAuth is in flight', async () => {
+    localStorage.setItem('is_logged_in', 'true');
+    localStorage.setItem('currentUser', 'Alice');
+
+    vi.mocked(fetch).mockImplementationOnce(async () => {
+      // Simulate another tab calling localStorage.clear() mid-flight
+      localStorage.clear();
+      return new Response(
+        JSON.stringify({ is_valid: true, role: 'Team Member', section: 'Seniors', is_leader: false }),
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+
+    const { result } = renderHook(() => useRequireAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+
+    expect(result.current.currentUser).toBeNull();
+  });
+
+  // Finding 1 (catch path): same race during a transient network error
+  it('redirects to /login when localStorage is cleared during a transient error', async () => {
+    localStorage.setItem('is_logged_in', 'true');
+    localStorage.setItem('currentUser', 'Alice');
+
+    vi.mocked(fetch).mockImplementationOnce(async () => {
+      localStorage.clear();
+      throw new TypeError('Network error');
+    });
+
+    renderHook(() => useRequireAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  // Finding 3: non-ok (e.g. 502) response — validateAuth returns false, user is redirected
+  it('redirects to /login when server returns a non-ok response', async () => {
+    localStorage.setItem('is_logged_in', 'true');
+    localStorage.setItem('currentUser', 'Dave');
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('<html>Bad Gateway</html>', { status: 502 })
+    );
+
+    renderHook(() => useRequireAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  // Finding 4 (stale metadata trade-off): during an outage the hook keeps users logged in,
+  // which means stale localStorage values like user_role/is_leader may persist.
+  // This is a deliberate trade-off to avoid logging users out during transient outages.
+  // Tracked in GitHub issue #135.
 });

--- a/frontend/src/__tests__/useRequireAuth.test.tsx
+++ b/frontend/src/__tests__/useRequireAuth.test.tsx
@@ -77,7 +77,7 @@ describe('useRequireAuth', () => {
     expect(localStorage.getItem('currentUser')).toBeNull();
   });
 
-  it('redirects to /login, clears storage, and sets loading=false when validateAuth throws', async () => {
+  it('keeps the user logged in on a transient network error', async () => {
     localStorage.setItem('is_logged_in', 'true');
     localStorage.setItem('currentUser', 'Charlie');
     vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Network error'));
@@ -85,11 +85,11 @@ describe('useRequireAuth', () => {
     const { result } = renderHook(() => useRequireAuth(), { wrapper });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/login');
+      expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.loading).toBe(false);
-    expect(result.current.currentUser).toBe(null);
-    expect(localStorage.getItem('currentUser')).toBeNull();
+    expect(result.current.currentUser).toBe('Charlie');
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(localStorage.getItem('currentUser')).toBe('Charlie');
   });
 });

--- a/frontend/src/__tests__/useRequireAuth.test.tsx
+++ b/frontend/src/__tests__/useRequireAuth.test.tsx
@@ -76,4 +76,20 @@ describe('useRequireAuth', () => {
 
     expect(localStorage.getItem('currentUser')).toBeNull();
   });
+
+  it('redirects to /login, clears storage, and sets loading=false when validateAuth throws', async () => {
+    localStorage.setItem('is_logged_in', 'true');
+    localStorage.setItem('currentUser', 'Charlie');
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Network error'));
+
+    const { result } = renderHook(() => useRequireAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.currentUser).toBe(null);
+    expect(localStorage.getItem('currentUser')).toBeNull();
+  });
 });

--- a/frontend/src/__tests__/useRequireAuth.test.tsx
+++ b/frontend/src/__tests__/useRequireAuth.test.tsx
@@ -133,19 +133,23 @@ describe('useRequireAuth', () => {
     });
   });
 
-  // Finding 3: non-ok (e.g. 502) response — validateAuth returns false, user is redirected
-  it('redirects to /login when server returns a non-ok response', async () => {
+  // A 5xx response throws from validateAuth, which useRequireAuth treats as transient —
+  // the session is preserved rather than forcing the user to /login.
+  it('preserves session when server returns a 5xx response (transient outage)', async () => {
     localStorage.setItem('is_logged_in', 'true');
     localStorage.setItem('currentUser', 'Dave');
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response('<html>Bad Gateway</html>', { status: 502 })
     );
 
-    renderHook(() => useRequireAuth(), { wrapper });
+    const { result } = renderHook(() => useRequireAuth(), { wrapper });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/login');
+      expect(result.current.loading).toBe(false);
     });
+
+    expect(result.current.currentUser).toBe('Dave');
+    expect(mockNavigate).not.toHaveBeenCalledWith('/login');
   });
 
   // Finding 4 (stale metadata trade-off): during an outage the hook keeps users logged in,

--- a/frontend/src/__tests__/useRequireAuth.test.tsx
+++ b/frontend/src/__tests__/useRequireAuth.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import { useRequireAuth } from '../hooks/useRequireAuth';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  vi.spyOn(globalThis, 'fetch').mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockValidateAuth(isValid: boolean) {
+  vi.mocked(fetch).mockResolvedValueOnce(
+    new Response(
+      JSON.stringify({ is_valid: isValid, role: 'Team Member', section: 'Seniors', is_leader: false }),
+      { headers: { 'Content-Type': 'application/json' } }
+    )
+  );
+}
+
+describe('useRequireAuth', () => {
+  it('sets currentUser and stops loading after successful auth', async () => {
+    localStorage.setItem('is_logged_in', 'true');
+    localStorage.setItem('currentUser', 'Alice');
+    mockValidateAuth(true);
+
+    const { result } = renderHook(() => useRequireAuth(), { wrapper });
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.currentUser).toBe('Alice');
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /login when not logged in', async () => {
+    // no localStorage entries
+
+    const { result } = renderHook(() => useRequireAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+
+    expect(result.current.currentUser).toBe(null);
+  });
+
+  it('redirects to /login and clears storage when validateAuth returns false', async () => {
+    localStorage.setItem('is_logged_in', 'true');
+    localStorage.setItem('currentUser', 'Bob');
+    mockValidateAuth(false);
+
+    renderHook(() => useRequireAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+
+    expect(localStorage.getItem('currentUser')).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/useRequireAuth.test.tsx
+++ b/frontend/src/__tests__/useRequireAuth.test.tsx
@@ -149,7 +149,7 @@ describe('useRequireAuth', () => {
     });
 
     expect(result.current.currentUser).toBe('Dave');
-    expect(mockNavigate).not.toHaveBeenCalledWith('/login');
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   // Finding 4 (stale metadata trade-off): during an outage the hook keeps users logged in,

--- a/frontend/src/hooks/useRequireAuth.ts
+++ b/frontend/src/hooks/useRequireAuth.ts
@@ -9,18 +9,26 @@ export function useRequireAuth(): { currentUser: string | null; loading: boolean
 
   useEffect(() => {
     const check = async () => {
-      if (!isLoggedIn() || !getCurrentUser()) {
-        navigate("/login");
-        return;
-      }
-      const isValid = await validateAuth();
-      if (!isValid) {
+      try {
+        if (!isLoggedIn() || !getCurrentUser()) {
+          navigate("/login");
+          setLoading(false);
+          return;
+        }
+        const isValid = await validateAuth();
+        if (!isValid) {
+          localStorage.clear();
+          navigate("/login");
+          setLoading(false);
+          return;
+        }
+        setCurrentUser(getCurrentUser());
+        setLoading(false);
+      } catch {
         localStorage.clear();
         navigate("/login");
-        return;
+        setLoading(false);
       }
-      setCurrentUser(getCurrentUser());
-      setLoading(false);
     };
     check();
   }, [navigate]);

--- a/frontend/src/hooks/useRequireAuth.ts
+++ b/frontend/src/hooks/useRequireAuth.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { isLoggedIn, getCurrentUser, validateAuth } from "../../api";
+
+export function useRequireAuth(): { currentUser: string | null; loading: boolean } {
+  const [currentUser, setCurrentUser] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const check = async () => {
+      if (!isLoggedIn() || !getCurrentUser()) {
+        navigate("/login");
+        return;
+      }
+      const isValid = await validateAuth();
+      if (!isValid) {
+        localStorage.clear();
+        navigate("/login");
+        return;
+      }
+      setCurrentUser(getCurrentUser());
+      setLoading(false);
+    };
+    check();
+  }, [navigate]);
+
+  return { currentUser, loading };
+}

--- a/frontend/src/hooks/useRequireAuth.ts
+++ b/frontend/src/hooks/useRequireAuth.ts
@@ -22,14 +22,31 @@ export function useRequireAuth(): { currentUser: string | null; loading: boolean
           setLoading(false);
           return;
         }
-        setCurrentUser(getCurrentUser());
+        // Re-read after await: another tab may have cleared localStorage while
+        // the server round-trip was in flight.
+        const user = getCurrentUser();
+        if (!user) {
+          navigate("/login");
+          setLoading(false);
+          return;
+        }
+        setCurrentUser(user);
         setLoading(false);
       } catch (error) {
         // Network/transport error: don't clear the session — the server may be
         // temporarily unavailable. Keep the user logged in so they aren't forced
         // out during a transient outage.
+        // Trade-off: stale localStorage metadata (e.g. user_role, is_leader) may
+        // persist if the server is down for an extended period and roles change in
+        // the DB during the outage. See GitHub issue #135 for tracking.
         console.error("Auth check failed (transient):", error);
-        setCurrentUser(getCurrentUser());
+        const user = getCurrentUser();
+        if (!user) {
+          navigate("/login");
+          setLoading(false);
+          return;
+        }
+        setCurrentUser(user);
         setLoading(false);
       }
     };

--- a/frontend/src/hooks/useRequireAuth.ts
+++ b/frontend/src/hooks/useRequireAuth.ts
@@ -24,9 +24,12 @@ export function useRequireAuth(): { currentUser: string | null; loading: boolean
         }
         setCurrentUser(getCurrentUser());
         setLoading(false);
-      } catch {
-        localStorage.clear();
-        navigate("/login");
+      } catch (error) {
+        // Network/transport error: don't clear the session — the server may be
+        // temporarily unavailable. Keep the user logged in so they aren't forced
+        // out during a transient outage.
+        console.error("Auth check failed (transient):", error);
+        setCurrentUser(getCurrentUser());
         setLoading(false);
       }
     };


### PR DESCRIPTION
## Summary

  This PR addresses four open issues (#126, #127, #128, #129) covering backend refactoring and a frontend auth pattern extraction. The changes are non-functional (no new features, no behaviour changes) — they
   reduce duplication, improve separation of concerns, and make the codebase easier to test.

  ---

  ### #127 — Move devos feedback orchestration out of route handler

  The `devos_feedback` route handler was doing its own database queries inline. Three functions have been extracted into `utils.py`:

  - `get_feedback_by_date(date_str)` — queries feedback joined with sections for a given date
  - `get_user_info(user_name)` — looks up a user's section, role, and leader status
  - `save_devos_feedback(section_name, date_str, new_feedback, editor_id)` — upserts feedback for a section

  The route handler now delegates to these utils functions and handles only HTTP concerns (status codes, JSON responses). Tests in `test_devos_feedback.py` updated to mock at the correct import binding.

  ---

  ### #126 — Separate cache layer from query logic in `utils.py`

  Introduced `backend/bcssm_backend/cache_utils.py` with a `cached_result` decorator and a TTL registry:

  - `cached_result(key_fn, ttl, error_ttl, on_error, cache)` — wraps any query function with get/set cache logic; supports static or callable cache keys, configurable fallback values, and injectable cache for
   testing
  - `get_ttl_registry()` — returns a dict of `{function_name: ttl}` for all decorated functions

  All 10 cached functions in `utils.py` refactored to use `@cached_result`, removing ~60 lines of repetitive cache boilerplate. New test file `test_cache_utils.py` covers cache miss/hit, dynamic keys, error
  fallback, and the TTL registry.

  ---

  ### #128 — Decompose `__init__.py`

  `create_app()` previously contained all route definitions inline. These have been extracted into dedicated modules:

  - `routes/admin.py` — `init_admin_routes(app)` (3 cache management endpoints: `POST /api/admin/cache/clear`, `GET /api/admin/cache/status`, `GET /api/admin/cache/info`) and `register_error_handlers(app)` (5
   HTTP error handlers). The `/info` endpoint uses `get_ttl_registry()` to derive the TTL display dynamically.
  - `routes/system.py` — `init_system_routes(app)` (`/api/sections`, `/api/health`, and the React SPA fallback catch-all)

  `__init__.py` is now a clean app factory with no inline route logic. `test_app.py` patch paths updated to match the new module locations.

  ---

  ### #129 — Extract frontend auth guard into a shared hook

  Five page components (`Home`, `DutiesPage`, `Sections`, `DevoFeedback`, `DevoFeedbackEdit`) each contained identical copy-pasted auth guard logic:

  isLoggedIn() → getCurrentUser() → validateAuth() → navigate('/login')

  This has been extracted into `frontend/src/hooks/useRequireAuth.ts`, which returns `{ currentUser, loading }`. Each component now:

  - Calls `useRequireAuth()` instead of the inline guard
  - Runs its data-fetch `useEffect` gated on `currentUser` (so fetches only fire after auth resolves)
  - Shows the loading spinner while either `authLoading` or `dataLoading` is true

  `DevoFeedback.tsx` additionally had its `isLoggedInState` boolean state removed — replaced with `currentUser !== null` in the render condition.

  New test file `frontend/src/__tests__/useRequireAuth.test.tsx` covers three cases: valid auth (sets `currentUser`, stops loading), unauthenticated (redirects to `/login`), and invalid token (clears
  localStorage, redirects to `/login`).

  ---

  ## Test plan

  - [ ] Backend: `PYTHONPATH=. pytest backend/tests/` — 282 tests pass
  - [ ] Frontend: `npm run test:run` — 71 tests pass (includes 3 new `useRequireAuth` tests)
  - [ ] Frontend: `npm run lint` — 0 errors
  - [ ] Manual smoke test: login, home page loads duty info, duties page loads, sections page loads, devos feedback view/edit works
  - [ ] Verify redirect to `/login` on unauthenticated access to any protected route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin cache tools: clear cache, view cache status/info
  * Health endpoint reporting app, database, and cache status
  * Improved SPA static-file handling/fallback for frontend routes

* **Refactor**
  * Centralized JSON error handling across the API
  * Unified caching decorator for backend read APIs with configurable TTLs and error fallbacks
  * Frontend: standardized auth flow via a shared hook used across pages/components

* **Tests**
  * Expanded coverage for caching, TTL registry, health/admin endpoints, auth, and static-file safety

* **Documentation**
  * Updated README and contributor guidance with architecture, caching, and testing details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlomeCS/BCSSM/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->