### PR TITLE
fix: sections 401 on Safari iOS (ITP cookie issue)

### DIFF
--- a/backend/bcssm_backend/routes/sections.py
+++ b/backend/bcssm_backend/routes/sections.py
@@ -1,7 +1,8 @@
 import logging
-from flask import jsonify, session
+from flask import jsonify
 from sqlalchemy.exc import SQLAlchemyError
 
+from backend.bcssm_backend.auth import get_username_from_request
 from backend.bcssm_backend.utils import get_all_sections_with_users, get_users_by_section_optimized
 
 logger = logging.getLogger(__name__)
@@ -14,12 +15,12 @@ def init_users_sections_routes(app):
         Returns: JSON with sections and their users
         """
         
-        user_name = session.get('user_name')
+        user_name = get_username_from_request()
         if not user_name:
             return jsonify({'error': 'User not authenticated'}), 401
-            
+
         try:
-            logger.info("Fetching users grouped by section")
+            logger.info("Fetching users grouped by section for user: %s", user_name)
             
             # Get all sections with their users
             sections_data = get_all_sections_with_users()
@@ -49,10 +50,10 @@ def init_users_sections_routes(app):
         """
         Get users for a specific section
         """
-        user_name = session.get('user_name')
+        user_name = get_username_from_request()
         if not user_name:
             return jsonify({'error': 'User not authenticated'}), 401
-            
+
         try:
             logger.info("Fetching users for section: %s", section_name)
             

--- a/backend/tests/test_sections.py
+++ b/backend/tests/test_sections.py
@@ -486,6 +486,33 @@ def test_both_endpoints_authentication_consistency(client):
         data2 = json.loads(response2.data)
         assert data2["error"] == "User not authenticated"
 
+def test_get_users_by_section_auth_via_query_param(client, mock_utils):
+    """Test that auth works via query param (no session cookie — Safari/iOS ITP scenario)"""
+    mock_sections, _ = mock_utils
+    mock_sections.return_value = []
+
+    # No session set — only query param, as Safari on iOS sends
+    response = client.get('/api/users/by-section?user_name=Dohn%20Joe')
+
+    if response.status_code == 404:
+        pytest.skip("Route not implemented yet")
+
+    assert response.status_code == 200
+
+
+def test_get_users_by_section_auth_via_header(client, mock_utils):
+    """Test that auth works via X-Current-User header (no session cookie)"""
+    mock_sections, _ = mock_utils
+    mock_sections.return_value = []
+
+    response = client.get('/api/users/by-section', headers={'X-Current-User': 'Dohn Joe'})
+
+    if response.status_code == 404:
+        pytest.skip("Route not implemented yet")
+
+    assert response.status_code == 200
+
+
 def test_route_exists(client):
     """Basic test to verify routes exist"""
     # Test that routes return something other than 404

--- a/backend/tests/test_sections.py
+++ b/backend/tests/test_sections.py
@@ -491,11 +491,7 @@ def test_get_users_by_section_auth_via_query_param(client, mock_utils):
     mock_sections, _ = mock_utils
     mock_sections.return_value = []
 
-    # No session set — only query param, as Safari on iOS sends
     response = client.get('/api/users/by-section?user_name=Dohn%20Joe')
-
-    if response.status_code == 404:
-        pytest.skip("Route not implemented yet")
 
     assert response.status_code == 200
 
@@ -507,8 +503,25 @@ def test_get_users_by_section_auth_via_header(client, mock_utils):
 
     response = client.get('/api/users/by-section', headers={'X-Current-User': 'Dohn Joe'})
 
-    if response.status_code == 404:
-        pytest.skip("Route not implemented yet")
+    assert response.status_code == 200
+
+
+def test_get_section_users_auth_via_query_param(client, mock_utils):
+    """Test section-specific route auth via query param (no session cookie)"""
+    _, mock_users = mock_utils
+    mock_users.return_value = []
+
+    response = client.get('/api/users/section/Minis?user_name=Dohn%20Joe')
+
+    assert response.status_code == 200
+
+
+def test_get_section_users_auth_via_header(client, mock_utils):
+    """Test section-specific route auth via X-Current-User header (no session cookie)"""
+    _, mock_users = mock_utils
+    mock_users.return_value = []
+
+    response = client.get('/api/users/section/Minis', headers={'X-Current-User': 'Dohn Joe'})
 
     assert response.status_code == 200
 


### PR DESCRIPTION
## Summary
- `sections.py` was authenticating via `session.get('user_name')` directly, bypassing the shared `get_username_from_request()` helper
- Safari on iOS applies ITP (Intelligent Tracking Prevention), which blocks the Flask session cookie on cross-origin requests to Render — causing a 401 for every request to `/api/users/by-section`
- The fix switches both routes to `get_username_from_request()`, which checks query params and the `X-Current-User` header before falling back to the session — the frontend already sends the username via both

## Root cause evidence
Backend log from iPhone:
```
GET /api/users/by-section?t=1779565930346&user_name=Dohn%20Joe HTTP/1.1" 401
```
The username was present in the query string; the route just never looked there.

## Test plan
- [x] All 25 existing + new `test_sections.py` tests pass
- [x] Added `test_get_users_by_section_auth_via_query_param` — verifies 200 with no session cookie, only query param
- [x] Added `test_get_users_by_section_auth_via_header` — verifies 200 with no session cookie, only `X-Current-User` header
- [ ] Deploy to Render and verify on iPhone Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication validation for the `/api/users/by-section` endpoint to return 401 errors when user authentication is missing.

* **Tests**
  * Added test cases to validate endpoint authentication handling across different authentication scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlomeCS/BCSSM/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->