### PR TITLE
Feature/add password functionality

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -140,6 +140,8 @@ jobs:
         coverage run -m pytest --junitxml=pytest-results.xml
         coverage report
         coverage xml
+    - name: Import Codecov GPG key
+      run: gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -141,7 +141,7 @@ jobs:
         coverage report
         coverage xml
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
@@ -150,7 +150,7 @@ jobs:
         fail_ci_if_error: true
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@9739113ad922ea0a9abb4b2c0f8bf6a4aa8ef820
+      uses: codecov/test-results-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./pytest-results.xml  # Path to the JUnit XML file
+        files: ./pytest-results.xml

--- a/backend/bcssm_backend/routes/admin.py
+++ b/backend/bcssm_backend/routes/admin.py
@@ -1,7 +1,9 @@
+import hmac
 import os
 import logging
 
-from flask import request, jsonify
+import bcrypt
+from flask import request, jsonify, session
 from redis.exceptions import RedisError
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.exceptions import HTTPException
@@ -10,6 +12,7 @@ from backend.bcssm_backend.exceptions import BaseError, CacheError
 from backend.bcssm_backend.utils import (
     clear_user_cache, clear_duty_cache, clear_feedback_cache, clear_all_cache,
     get_cache_status, get_cache_info, _redact_redis_url,
+    execute_query, execute_readonly_query,
 )
 
 logger = logging.getLogger(__name__)
@@ -61,6 +64,81 @@ def init_admin_routes(app):
     @app.route("/api/admin/cache/info", methods=['GET'])
     def cache_info():
         return jsonify(get_cache_info())
+
+    def _is_authorized_admin():
+        """Returns True if the request carries a valid admin credential.
+
+        Accepts either:
+        - a logged-in session whose user has role 'Admin' (fast path), or
+        - a session with a user_name whose DB role is 'Admin' (handles stale sessions
+          created before user_role was added to the session), or
+        - a matching X-Admin-Secret header (bootstrap / out-of-band access).
+        """
+        if session.get('user_role') == 'Admin':
+            return True
+        user_name = session.get('user_name')
+        if user_name:
+            try:
+                rows = execute_readonly_query(
+                    "SELECT role FROM users WHERE name = :name",
+                    {'name': user_name},
+                    silent=True,
+                )
+                if rows and rows[0][0] == 'Admin':
+                    session['user_role'] = 'Admin'
+                    return True
+            except SQLAlchemyError:
+                pass
+        admin_secret = os.getenv('ADMIN_SECRET', '').strip()
+        provided = request.headers.get('X-Admin-Secret', '').strip()
+        if not admin_secret:
+            logger.warning("Admin endpoint called but ADMIN_SECRET env var is not set")
+            return False
+        if not provided:
+            logger.warning("Admin endpoint called with no X-Admin-Secret header")
+            return False
+        result = hmac.compare_digest(provided, admin_secret)
+        if not result:
+            logger.warning("Admin endpoint called with incorrect X-Admin-Secret header")
+        return result
+
+    @app.route("/api/admin/passwords-status", methods=['GET'])
+    def passwords_status():
+        if not _is_authorized_admin():
+            return jsonify({'error': 'Unauthorized'}), 403
+        try:
+            rows = execute_readonly_query(
+                "SELECT u.name, (u.password_hash IS NOT NULL) AS has_password "
+                "FROM users u ORDER BY u.name"
+            )
+            return jsonify({'users': [{'name': r[0], 'has_password': bool(r[1])} for r in rows]}), 200
+        except SQLAlchemyError as e:
+            logger.error("Failed to fetch password status: %s", e)
+            return jsonify({'error': 'Database error'}), 500
+
+    @app.route("/api/admin/set-password", methods=['POST'])
+    def set_password():
+        if not _is_authorized_admin():
+            return jsonify({'error': 'Unauthorized'}), 403
+        data = request.json or {}
+        user_name = (data.get('user_name') or '').strip()
+        password = data.get('password') or ''
+        if not user_name or not password:
+            return jsonify({'error': 'user_name and password required'}), 400
+        if len(password) < 8:
+            return jsonify({'error': 'Password must be at least 8 characters'}), 400
+        password_hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
+        try:
+            rows = execute_query(
+                "UPDATE users SET password_hash = :hash WHERE name = :name RETURNING id",
+                {'hash': password_hash, 'name': user_name}
+            )
+            if not rows:
+                return jsonify({'error': 'User not found'}), 404
+            return jsonify({'ok': True, 'user_name': user_name}), 200
+        except SQLAlchemyError as e:
+            logger.error("Failed to set password for %s: %s", user_name, e)
+            return jsonify({'error': 'Database error'}), 500
 
 
 def register_error_handlers(app):

--- a/backend/bcssm_backend/routes/admin.py
+++ b/backend/bcssm_backend/routes/admin.py
@@ -12,7 +12,7 @@ from backend.bcssm_backend.exceptions import BaseError, CacheError
 from backend.bcssm_backend.utils import (
     clear_user_cache, clear_duty_cache, clear_feedback_cache, clear_all_cache,
     get_cache_status, get_cache_info, _redact_redis_url,
-    execute_query, execute_readonly_query,
+    get_user_role, get_all_users_password_status, set_user_password,
 )
 
 logger = logging.getLogger(__name__)
@@ -79,12 +79,7 @@ def init_admin_routes(app):
         user_name = session.get('user_name')
         if user_name:
             try:
-                rows = execute_readonly_query(
-                    "SELECT role FROM users WHERE name = :name",
-                    {'name': user_name},
-                    silent=True,
-                )
-                if rows and rows[0][0] == 'Admin':
+                if get_user_role(user_name) == 'Admin':
                     session['user_role'] = 'Admin'
                     return True
             except SQLAlchemyError:
@@ -107,17 +102,13 @@ def init_admin_routes(app):
         if not _is_authorized_admin():
             return jsonify({'error': 'Unauthorized'}), 403
         try:
-            rows = execute_readonly_query(
-                "SELECT u.name, (u.password_hash IS NOT NULL) AS has_password "
-                "FROM users u ORDER BY u.name"
-            )
-            return jsonify({'users': [{'name': r[0], 'has_password': bool(r[1])} for r in rows]}), 200
+            return jsonify({'users': get_all_users_password_status()}), 200
         except SQLAlchemyError as e:
             logger.error("Failed to fetch password status: %s", e)
             return jsonify({'error': 'Database error'}), 500
 
     @app.route("/api/admin/set-password", methods=['POST'])
-    def set_password():
+    def admin_set_password():
         if not _is_authorized_admin():
             return jsonify({'error': 'Unauthorized'}), 403
         data = request.json or {}
@@ -129,11 +120,8 @@ def init_admin_routes(app):
             return jsonify({'error': 'Password must be at least 8 characters'}), 400
         password_hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
         try:
-            rows = execute_query(
-                "UPDATE users SET password_hash = :hash WHERE name = :name RETURNING id",
-                {'hash': password_hash, 'name': user_name}
-            )
-            if not rows:
+            found = set_user_password(user_name, password_hash)
+            if not found:
                 return jsonify({'error': 'User not found'}), 404
             return jsonify({'ok': True, 'user_name': user_name}), 200
         except SQLAlchemyError as e:

--- a/backend/bcssm_backend/routes/users.py
+++ b/backend/bcssm_backend/routes/users.py
@@ -141,12 +141,14 @@ def init_users_routes(app):
     def api_login():
         """Establish a server-side session for the React login flow."""
         data = request.json or {}
-        user_name = (data.get('user_name') or '').strip()
-        password = data.get('password') or ''
-        if not user_name:
+        raw_user_name = data.get('user_name')
+        raw_password = data.get('password')
+        if not isinstance(raw_user_name, str) or not raw_user_name.strip():
             return jsonify({'error': 'user_name required'}), 400
-        if not password:
+        if not isinstance(raw_password, str) or not raw_password:
             return jsonify({'error': 'password required'}), 400
+        user_name = raw_user_name.strip()
+        password = raw_password
         try:
             user = authenticate_user(user_name, password)
         except AuthenticationError:

--- a/backend/bcssm_backend/routes/users.py
+++ b/backend/bcssm_backend/routes/users.py
@@ -142,12 +142,15 @@ def init_users_routes(app):
         """Establish a server-side session for the React login flow."""
         data = request.json or {}
         user_name = (data.get('user_name') or '').strip()
+        password = data.get('password') or ''
         if not user_name:
             return jsonify({'error': 'user_name required'}), 400
+        if not password:
+            return jsonify({'error': 'password required'}), 400
         try:
-            user = authenticate_user(user_name)
+            user = authenticate_user(user_name, password)
         except AuthenticationError:
-            return jsonify({'error': 'Invalid user'}), 401
+            return jsonify({'error': 'Invalid credentials'}), 401
         except SQLAlchemyError as e:
             app.logger.error("Login DB error for %s: %s", user_name, e)
             return jsonify({'error': 'An internal error has occurred.'}), 500
@@ -155,6 +158,7 @@ def init_users_routes(app):
             'user_name': user['name'],
             'user_id': user['id'],
             'user_section': user['section_name'],
+            'user_role': user['role'],
             'is_leader': user['is_leader'],
         })
         cache_user_login(user)

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -51,21 +51,29 @@ def execute_readonly_query(query, params=None, silent=False):
 
 user_assignments = {}
 
-def execute_query(query, params=None):
+def execute_query(query, params=None, silent=False):
     try:
         with db.session.begin():
-            logger.info("Executing query: %s with params: %s", query, params)
+            if not silent:
+                logger.info("Executing query: %s with params: %s", query, params)
             result = db.session.execute(text(query), params)
             if result.returns_rows:
                 rows = result.fetchall()
-                logger.info("Raw rows fetched: %s", rows)
+                if not silent:
+                    logger.info("Raw rows fetched: %s", rows)
                 return rows
-            logger.info("Query executed successfully with no rows returned.")
+            if not silent:
+                logger.info("Query executed successfully with no rows returned.")
             return None
 
     except SQLAlchemyError as e:
         db.session.rollback()
-        logger.error("Query failed. Query: %s, Params: %s, Error: %s", query, params, e)
+        logger.error(
+            "Query failed. Query: %s, Params: %s, Error: %s",
+            query,
+            "<redacted>" if silent else params,
+            e,
+        )
         raise
 
 @cached_result('users:all:list', 900, on_error=[])
@@ -682,7 +690,8 @@ def set_user_password(user_name: str, password_hash: str) -> bool:
     """Write a bcrypt hash for a user. Returns True if the user was found."""
     rows = execute_query(
         "UPDATE users SET password_hash = :hash WHERE name = :name RETURNING id",
-        {'hash': password_hash, 'name': user_name}
+        {'hash': password_hash, 'name': user_name},
+        silent=True,
     )
     return bool(rows)
 

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -644,7 +644,11 @@ def authenticate_user(user_name: str, password: str) -> dict:
     user_id, name, role, section_name, password_hash = rows[0]
     if not password_hash:
         raise AuthenticationError("Invalid credentials")
-    if not bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8")):
+    try:
+        is_valid = bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
+    except (ValueError, TypeError):
+        raise AuthenticationError("Invalid credentials")
+    if not is_valid:
         raise AuthenticationError("Invalid credentials")
     return {
         "id": user_id,
@@ -653,6 +657,34 @@ def authenticate_user(user_name: str, password: str) -> dict:
         "section_name": section_name,
         "is_leader": role in {"Section Leader", "Team Leader", "Admin"},
     }
+
+
+def get_user_role(user_name: str):
+    """Return the role string for a user, or None if not found."""
+    rows = execute_readonly_query(
+        "SELECT role FROM users WHERE name = :name",
+        {'name': user_name},
+        silent=True,
+    )
+    return rows[0][0] if rows else None
+
+
+def get_all_users_password_status() -> list:
+    """Return list of {name, has_password} dicts ordered by name."""
+    rows = execute_readonly_query(
+        "SELECT u.name, (u.password_hash IS NOT NULL) AS has_password "
+        "FROM users u ORDER BY u.name"
+    )
+    return [{'name': r[0], 'has_password': bool(r[1])} for r in rows]
+
+
+def set_user_password(user_name: str, password_hash: str) -> bool:
+    """Write a bcrypt hash for a user. Returns True if the user was found."""
+    rows = execute_query(
+        "UPDATE users SET password_hash = :hash WHERE name = :name RETURNING id",
+        {'hash': password_hash, 'name': user_name}
+    )
+    return bool(rows)
 
 
 def cache_user_login(user_data: dict) -> None:

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -1,9 +1,12 @@
+import hmac
 import logging
 import os
 import urllib.parse
 from datetime import datetime, timedelta
 from collections import defaultdict
 from functools import lru_cache
+
+import bcrypt
 
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
@@ -626,10 +629,10 @@ def get_health_status() -> dict:
     return health
 
 
-def authenticate_user(user_name: str) -> dict:
-    """Validate user_name against DB and return user dict. Raises AuthenticationError if not found."""
+def authenticate_user(user_name: str, password: str) -> dict:
+    """Validate credentials against DB. Raises AuthenticationError on any failure."""
     rows = execute_readonly_query(
-        "SELECT u.id, u.name, u.role, COALESCE(s.name, 'Unassigned') AS section_name "
+        "SELECT u.id, u.name, u.role, COALESCE(s.name, 'Unassigned') AS section_name, u.password_hash "
         "FROM users u "
         "LEFT JOIN sections s ON u.section_id = s.id "
         "WHERE u.name = :user_name",
@@ -637,8 +640,12 @@ def authenticate_user(user_name: str) -> dict:
         silent=True,
     )
     if not rows:
-        raise AuthenticationError("Invalid user")
-    user_id, name, role, section_name = rows[0]
+        raise AuthenticationError("Invalid credentials")
+    user_id, name, role, section_name, password_hash = rows[0]
+    if not password_hash:
+        raise AuthenticationError("Invalid credentials")
+    if not bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8")):
+        raise AuthenticationError("Invalid credentials")
     return {
         "id": user_id,
         "name": name,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,4 @@ gunicorn==26.0.0
 redis==8.0.0
 pytest-cov==7.1.0
 pylint==4.0.5
+bcrypt==4.3.0

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import SQLAlchemyError
 
 from backend.bcssm_backend.utils import _fmt_ttl, _redact_redis_url
 from backend.bcssm_backend import create_app
@@ -151,3 +152,249 @@ def test_path_traversal_dot_dot_blocked(app, tmp_path, monkeypatch):
         resp = c.get("/../../credentials.txt")
         assert resp.status_code == 200
         assert b"SENSITIVE" not in resp.data
+
+
+# ─── _is_authorized_admin: session fast path ─────────────────────────────────
+
+def test_passwords_status_session_admin_fast_path(client, monkeypatch):
+    """Session with user_role='Admin' grants access without DB lookup or secret."""
+    fake_status = [{"name": "Alice", "has_password": True}]
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.get_all_users_password_status",
+        lambda: fake_status,
+    )
+    with client.session_transaction() as sess:
+        sess["user_role"] = "Admin"
+
+    resp = client.get("/api/admin/passwords-status")
+    assert resp.status_code == 200
+    assert resp.get_json()["users"] == fake_status
+
+
+def test_passwords_status_session_username_db_admin(client, monkeypatch):
+    """Session with user_name gets DB lookup; Admin role grants access."""
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.get_user_role",
+        lambda _: "Admin",
+    )
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.get_all_users_password_status",
+        lambda: [],
+    )
+    with client.session_transaction() as sess:
+        sess["user_name"] = "Harrison"
+
+    resp = client.get("/api/admin/passwords-status")
+    assert resp.status_code == 200
+    # Confirm session was updated with the looked-up role
+    with client.session_transaction() as sess:
+        assert sess.get("user_role") == "Admin"
+
+
+def test_passwords_status_session_username_non_admin_falls_through(client, monkeypatch):
+    """Session with user_name whose DB role is not Admin falls through to secret check."""
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.get_user_role",
+        lambda _: "Team Member",
+    )
+    monkeypatch.setenv("ADMIN_SECRET", "correct-secret")
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.get_all_users_password_status",
+        lambda: [],
+    )
+    with client.session_transaction() as sess:
+        sess["user_name"] = "Bob"
+
+    resp = client.get(
+        "/api/admin/passwords-status",
+        headers={"X-Admin-Secret": "correct-secret"},
+    )
+    assert resp.status_code == 200
+
+
+def test_passwords_status_session_username_db_error_falls_through(client, monkeypatch):
+    """SQLAlchemyError during DB role lookup falls through to secret check."""
+    def raise_db_error(_):
+        raise SQLAlchemyError("db down")
+
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.get_user_role",
+        raise_db_error,
+    )
+    monkeypatch.setenv("ADMIN_SECRET", "correct-secret")
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.get_all_users_password_status",
+        lambda: [],
+    )
+    with client.session_transaction() as sess:
+        sess["user_name"] = "Harrison"
+
+    resp = client.get(
+        "/api/admin/passwords-status",
+        headers={"X-Admin-Secret": "correct-secret"},
+    )
+    assert resp.status_code == 200
+
+
+def test_passwords_status_no_admin_secret_env_returns_403(client, monkeypatch):
+    """No ADMIN_SECRET env var → 403 even with a header."""
+    monkeypatch.delenv("ADMIN_SECRET", raising=False)
+    resp = client.get(
+        "/api/admin/passwords-status",
+        headers={"X-Admin-Secret": "anything"},
+    )
+    assert resp.status_code == 403
+
+
+def test_passwords_status_no_header_returns_403(client, monkeypatch):
+    """ADMIN_SECRET set but no X-Admin-Secret header → 403."""
+    monkeypatch.setenv("ADMIN_SECRET", "correct-secret")
+    resp = client.get("/api/admin/passwords-status")
+    assert resp.status_code == 403
+
+
+def test_passwords_status_wrong_header_returns_403(client, monkeypatch):
+    """Wrong X-Admin-Secret value → 403."""
+    monkeypatch.setenv("ADMIN_SECRET", "correct-secret")
+    resp = client.get(
+        "/api/admin/passwords-status",
+        headers={"X-Admin-Secret": "wrong-secret"},
+    )
+    assert resp.status_code == 403
+
+
+def test_passwords_status_correct_header_returns_200(client, monkeypatch):
+    """Correct X-Admin-Secret → 200 with users list."""
+    monkeypatch.setenv("ADMIN_SECRET", "correct-secret")
+    fake_users = [{"name": "Alice", "has_password": True}]
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.get_all_users_password_status",
+        lambda: fake_users,
+    )
+    resp = client.get(
+        "/api/admin/passwords-status",
+        headers={"X-Admin-Secret": "correct-secret"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["users"] == fake_users
+
+
+def test_passwords_status_db_error_returns_500(client, monkeypatch):
+    """SQLAlchemyError from get_all_users_password_status → 500."""
+    monkeypatch.setenv("ADMIN_SECRET", "correct-secret")
+
+    def raise_db_error():
+        raise SQLAlchemyError("db down")
+
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.get_all_users_password_status",
+        raise_db_error,
+    )
+    resp = client.get(
+        "/api/admin/passwords-status",
+        headers={"X-Admin-Secret": "correct-secret"},
+    )
+    assert resp.status_code == 500
+
+
+# ─── /api/admin/set-password ─────────────────────────────────────────────────
+
+def _auth_headers(monkeypatch):
+    monkeypatch.setenv("ADMIN_SECRET", "correct-secret")
+    return {"X-Admin-Secret": "correct-secret"}
+
+
+def test_set_password_unauthorized_returns_403(client, monkeypatch):
+    monkeypatch.delenv("ADMIN_SECRET", raising=False)
+    resp = client.post(
+        "/api/admin/set-password",
+        json={"user_name": "Alice", "password": "validpassword"},
+    )
+    assert resp.status_code == 403
+
+
+def test_set_password_missing_user_name_returns_400(client, monkeypatch):
+    headers = _auth_headers(monkeypatch)
+    resp = client.post(
+        "/api/admin/set-password",
+        json={"password": "validpassword"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+    assert "user_name" in resp.get_json()["error"]
+
+
+def test_set_password_missing_password_returns_400(client, monkeypatch):
+    headers = _auth_headers(monkeypatch)
+    resp = client.post(
+        "/api/admin/set-password",
+        json={"user_name": "Alice"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_set_password_too_short_returns_400(client, monkeypatch):
+    headers = _auth_headers(monkeypatch)
+    resp = client.post(
+        "/api/admin/set-password",
+        json={"user_name": "Alice", "password": "short"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+    assert "8 characters" in resp.get_json()["error"]
+
+
+def test_set_password_user_not_found_returns_404(client, monkeypatch):
+    headers = _auth_headers(monkeypatch)
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.set_user_password",
+        lambda user_name, password_hash: False,
+    )
+    with patch("backend.bcssm_backend.routes.admin.bcrypt.hashpw", return_value=b"$2b$12$fakehash"):
+        with patch("backend.bcssm_backend.routes.admin.bcrypt.gensalt", return_value=b"$2b$12$"):
+            resp = client.post(
+                "/api/admin/set-password",
+                json={"user_name": "Ghost", "password": "validpassword"},
+                headers=headers,
+            )
+    assert resp.status_code == 404
+
+
+def test_set_password_success_returns_200(client, monkeypatch):
+    headers = _auth_headers(monkeypatch)
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.set_user_password",
+        lambda user_name, password_hash: True,
+    )
+    with patch("backend.bcssm_backend.routes.admin.bcrypt.hashpw", return_value=b"$2b$12$fakehash"):
+        with patch("backend.bcssm_backend.routes.admin.bcrypt.gensalt", return_value=b"$2b$12$"):
+            resp = client.post(
+                "/api/admin/set-password",
+                json={"user_name": "Alice", "password": "validpassword"},
+                headers=headers,
+            )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["user_name"] == "Alice"
+
+
+def test_set_password_db_error_returns_500(client, monkeypatch):
+    headers = _auth_headers(monkeypatch)
+
+    def raise_db_error(user_name, password_hash):
+        raise SQLAlchemyError("db down")
+
+    monkeypatch.setattr(
+        "backend.bcssm_backend.routes.admin.set_user_password",
+        raise_db_error,
+    )
+    with patch("backend.bcssm_backend.routes.admin.bcrypt.hashpw", return_value=b"$2b$12$fakehash"):
+        with patch("backend.bcssm_backend.routes.admin.bcrypt.gensalt", return_value=b"$2b$12$"):
+            resp = client.post(
+                "/api/admin/set-password",
+                json={"user_name": "Alice", "password": "validpassword"},
+                headers=headers,
+            )
+    assert resp.status_code == 500

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -3,7 +3,6 @@
 import logging
 import os
 from unittest.mock import MagicMock, patch
-import json
 
 import pytest
 from flask import Flask

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -643,7 +643,7 @@ def test_api_login_success(client, patch_helpers):
         "section_name": "Minis", "is_leader": True,
     }
 
-    resp = client.post("/api/auth/login", json={"user_name": "Alice"})
+    resp = client.post("/api/auth/login", json={"user_name": "Alice", "password": "secret123"})
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["ok"] is True
@@ -664,7 +664,7 @@ def test_api_login_calls_cache_user_login(client, patch_helpers):
             "section_name": "Seniors", "is_leader": False}
     ph["authenticate_user"].return_value = user
 
-    client.post("/api/auth/login", json={"user_name": "Bob"})
+    client.post("/api/auth/login", json={"user_name": "Bob", "password": "secret123"})
 
     ph["cache_user_login"].assert_called_once_with(user)
 
@@ -677,7 +677,7 @@ def test_api_login_name_with_apostrophe(client, patch_helpers):
         "section_name": "Minis", "is_leader": False,
     }
 
-    resp = client.post("/api/auth/login", json={"user_name": "O'Reilly"})
+    resp = client.post("/api/auth/login", json={"user_name": "O'Reilly", "password": "secret123"})
     assert resp.status_code == 200
 
     called_with = ph["authenticate_user"].call_args[0][0]
@@ -691,14 +691,21 @@ def test_api_login_missing_user_name(client, patch_helpers):
     assert "user_name required" in resp.get_json()["error"]
 
 
+def test_api_login_missing_password(client, patch_helpers):
+    """POST body without password → 400."""
+    resp = client.post("/api/auth/login", json={"user_name": "Alice"})
+    assert resp.status_code == 400
+    assert "password required" in resp.get_json()["error"]
+
+
 def test_api_login_invalid_user(client, patch_helpers):
     """authenticate_user raises AuthenticationError → 401."""
     ph = patch_helpers
     ph["authenticate_user"].side_effect = AuthenticationError("Invalid user")
 
-    resp = client.post("/api/auth/login", json={"user_name": "Ghost"})
+    resp = client.post("/api/auth/login", json={"user_name": "Ghost", "password": "secret123"})
     assert resp.status_code == 401
-    assert "Invalid user" in resp.get_json()["error"]
+    assert "Invalid credentials" in resp.get_json()["error"]
 
 
 def test_api_login_db_error(client, patch_helpers):
@@ -706,7 +713,7 @@ def test_api_login_db_error(client, patch_helpers):
     ph = patch_helpers
     ph["authenticate_user"].side_effect = SQLAlchemyError("db down")
 
-    resp = client.post("/api/auth/login", json={"user_name": "Alice"})
+    resp = client.post("/api/auth/login", json={"user_name": "Alice", "password": "secret123"})
     assert resp.status_code == 500
     assert "internal error" in resp.get_json()["error"].lower()
 
@@ -719,7 +726,7 @@ def test_api_login_non_leader_role(client, patch_helpers):
         "section_name": "Minis", "is_leader": False,
     }
 
-    resp = client.post("/api/auth/login", json={"user_name": "Dave"})
+    resp = client.post("/api/auth/login", json={"user_name": "Dave", "password": "secret123"})
     assert resp.status_code == 200
     assert resp.get_json()["is_leader"] is False
 

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1556,15 +1556,24 @@ def test_authenticate_user_null_section_coalesced(mock_readonly, mocker):
 
 
 def test_authenticate_user_uses_silent_query(mock_readonly, mocker, caplog):
-    """Auth lookup must not emit user_name or row data at INFO level."""
+    """Auth lookup must pass silent=True and not emit sensitive data at INFO level."""
     import logging
     mock_readonly.return_value = [(1, "Alice", "Section Leader", "Minis", _FAKE_HASH)]
     mocker.patch("backend.bcssm_backend.utils.bcrypt.checkpw", return_value=True)
     with caplog.at_level(logging.INFO, logger="backend.bcssm_backend.utils"):
         utils.authenticate_user("Alice", "secret123")
+    assert mock_readonly.call_args.kwargs.get("silent") is True
     info_messages = [r.message for r in caplog.records if r.levelno == logging.INFO]
     assert not any("Alice" in m for m in info_messages)
     assert not any("user_name" in m for m in info_messages)
+
+
+def test_authenticate_user_malformed_hash_raises(mock_readonly, mocker):
+    """A malformed stored hash must raise AuthenticationError, not propagate ValueError."""
+    mock_readonly.return_value = [(1, "Alice", "Section Leader", "Minis", _FAKE_HASH)]
+    mocker.patch("backend.bcssm_backend.utils.bcrypt.checkpw", side_effect=ValueError("invalid hash"))
+    with pytest.raises(AuthenticationError):
+        utils.authenticate_user("Alice", "secret123")
 
 
 def test_authenticate_user_db_error_propagates(mock_readonly):

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1658,3 +1658,23 @@ def test_set_user_password_not_found(mock_db_session):
     mock_result.fetchall.return_value = []
     mock_db_session.execute.return_value = mock_result
     assert utils.set_user_password("Ghost", "$2b$12$hash") is False
+
+
+def test_set_user_password_redacts_hash_in_error_log(caplog):
+    """On DB failure, execute_query must log '<redacted>' not the real bcrypt hash."""
+    import logging
+    _real_execute_query = utils.execute_query
+    with patch('backend.bcssm_backend.utils.db') as mock_db:
+        mock_db.session.begin.return_value.__enter__ = MagicMock(return_value=mock_db.session)
+        mock_db.session.begin.return_value.__exit__ = MagicMock(return_value=None)
+        mock_db.session.execute.side_effect = SQLAlchemyError("db down")
+        with caplog.at_level(logging.ERROR, logger="backend.bcssm_backend.utils"):
+            with pytest.raises(SQLAlchemyError):
+                _real_execute_query(
+                    "UPDATE users SET password_hash = :hash WHERE name = :name RETURNING id",
+                    {'hash': '$2b$12$realhash', 'name': 'Alice'},
+                    silent=True,
+                )
+    error_messages = " ".join(r.getMessage() for r in caplog.records if r.levelno == logging.ERROR)
+    assert "$2b$12$realhash" not in error_messages
+    assert "<redacted>" in error_messages

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1512,9 +1512,13 @@ def test_save_devos_feedback_does_not_clear_cache_when_section_not_found(monkeyp
 
 
 # ─── authenticate_user ────────────────────────────────────────────────────────
-def test_authenticate_user_success(mock_readonly):
-    mock_readonly.return_value = [(1, "Alice", "Section Leader", "Minis")]
-    result = utils.authenticate_user("Alice")
+_FAKE_HASH = "$2b$12$fakehashfakehashfakehashfakehashfakehashfakehashfakeha"
+
+
+def test_authenticate_user_success(mock_readonly, mocker):
+    mock_readonly.return_value = [(1, "Alice", "Section Leader", "Minis", _FAKE_HASH)]
+    mocker.patch("backend.bcssm_backend.utils.bcrypt.checkpw", return_value=True)
+    result = utils.authenticate_user("Alice", "secret123")
     assert result == {
         "id": 1,
         "name": "Alice",
@@ -1527,21 +1531,37 @@ def test_authenticate_user_success(mock_readonly):
 def test_authenticate_user_not_found_raises(mock_readonly):
     mock_readonly.return_value = []
     with pytest.raises(AuthenticationError):
-        utils.authenticate_user("Ghost")
+        utils.authenticate_user("Ghost", "secret123")
 
 
-def test_authenticate_user_null_section_coalesced(mock_readonly):
-    mock_readonly.return_value = [(1, "Alice", "Team Member", "Unassigned")]
-    result = utils.authenticate_user("Alice")
+def test_authenticate_user_no_password_hash_raises(mock_readonly):
+    """Users with NULL password_hash cannot log in."""
+    mock_readonly.return_value = [(1, "Alice", "Section Leader", "Minis", None)]
+    with pytest.raises(AuthenticationError):
+        utils.authenticate_user("Alice", "secret123")
+
+
+def test_authenticate_user_wrong_password_raises(mock_readonly, mocker):
+    mock_readonly.return_value = [(1, "Alice", "Section Leader", "Minis", _FAKE_HASH)]
+    mocker.patch("backend.bcssm_backend.utils.bcrypt.checkpw", return_value=False)
+    with pytest.raises(AuthenticationError):
+        utils.authenticate_user("Alice", "wrongpassword")
+
+
+def test_authenticate_user_null_section_coalesced(mock_readonly, mocker):
+    mock_readonly.return_value = [(1, "Alice", "Team Member", "Unassigned", _FAKE_HASH)]
+    mocker.patch("backend.bcssm_backend.utils.bcrypt.checkpw", return_value=True)
+    result = utils.authenticate_user("Alice", "secret123")
     assert result["section_name"] == "Unassigned"
 
 
-def test_authenticate_user_uses_silent_query(mock_readonly, caplog):
+def test_authenticate_user_uses_silent_query(mock_readonly, mocker, caplog):
     """Auth lookup must not emit user_name or row data at INFO level."""
     import logging
-    mock_readonly.return_value = [(1, "Alice", "Section Leader", "Minis")]
+    mock_readonly.return_value = [(1, "Alice", "Section Leader", "Minis", _FAKE_HASH)]
+    mocker.patch("backend.bcssm_backend.utils.bcrypt.checkpw", return_value=True)
     with caplog.at_level(logging.INFO, logger="backend.bcssm_backend.utils"):
-        utils.authenticate_user("Alice")
+        utils.authenticate_user("Alice", "secret123")
     info_messages = [r.message for r in caplog.records if r.levelno == logging.INFO]
     assert not any("Alice" in m for m in info_messages)
     assert not any("user_name" in m for m in info_messages)
@@ -1550,7 +1570,7 @@ def test_authenticate_user_uses_silent_query(mock_readonly, caplog):
 def test_authenticate_user_db_error_propagates(mock_readonly):
     mock_readonly.side_effect = SQLAlchemyError("db down")
     with pytest.raises(SQLAlchemyError):
-        utils.authenticate_user("Alice")
+        utils.authenticate_user("Alice", "secret123")
 
 
 @pytest.mark.parametrize("role,expected", [
@@ -1559,9 +1579,10 @@ def test_authenticate_user_db_error_propagates(mock_readonly):
     ("Admin", True),
     ("Team Member", False),
 ])
-def test_authenticate_user_is_leader_roles(mock_readonly, role, expected):
-    mock_readonly.return_value = [(1, "Alice", role, "Minis")]
-    result = utils.authenticate_user("Alice")
+def test_authenticate_user_is_leader_roles(mock_readonly, mocker, role, expected):
+    mock_readonly.return_value = [(1, "Alice", role, "Minis", _FAKE_HASH)]
+    mocker.patch("backend.bcssm_backend.utils.bcrypt.checkpw", return_value=True)
+    result = utils.authenticate_user("Alice", "secret123")
     assert result["is_leader"] is expected
 
 

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1617,3 +1617,44 @@ def test_evict_user_login_cache_deletes_correct_key(mock_cache):
 def test_evict_user_login_cache_swallows_redis_error(mock_cache):
     mock_cache.delete.side_effect = RedisError("Redis down")
     utils.evict_user_login_cache("Alice")  # must not raise
+
+
+# ─── get_user_role ────────────────────────────────────────────────────────────
+def test_get_user_role_found(mock_readonly):
+    mock_readonly.return_value = [("Admin",)]
+    result = utils.get_user_role("Harrison")
+    assert result == "Admin"
+    assert mock_readonly.call_args.kwargs.get("silent") is True
+
+
+def test_get_user_role_not_found(mock_readonly):
+    mock_readonly.return_value = []
+    result = utils.get_user_role("Ghost")
+    assert result is None
+
+
+# ─── get_all_users_password_status ───────────────────────────────────────────
+def test_get_all_users_password_status(mock_readonly):
+    mock_readonly.return_value = [("Alice", True), ("Bob", False)]
+    result = utils.get_all_users_password_status()
+    assert result == [
+        {"name": "Alice", "has_password": True},
+        {"name": "Bob", "has_password": False},
+    ]
+
+
+# ─── set_user_password ────────────────────────────────────────────────────────
+def test_set_user_password_found(mock_db_session):
+    mock_result = MagicMock()
+    mock_result.returns_rows = True
+    mock_result.fetchall.return_value = [(1,)]
+    mock_db_session.execute.return_value = mock_result
+    assert utils.set_user_password("Alice", "$2b$12$hash") is True
+
+
+def test_set_user_password_not_found(mock_db_session):
+    mock_result = MagicMock()
+    mock_result.returns_rows = True
+    mock_result.fetchall.return_value = []
+    mock_db_session.execute.return_value = mock_result
+    assert utils.set_user_password("Ghost", "$2b$12$hash") is False

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -37,8 +37,8 @@ export const getCurrentUser = (): string | null => {
     });
   };
   
-  export const login = (userName: string): Promise<Response> => {
-    return apiPost('/api/auth/login', { user_name: userName });
+  export const login = (userName: string, password: string): Promise<Response> => {
+    return apiPost('/api/auth/login', { user_name: userName, password });
   };
 
   export const logout = async (): Promise<void> => {

--- a/frontend/src/AdminPasswords.css
+++ b/frontend/src/AdminPasswords.css
@@ -1,0 +1,185 @@
+.admin-page {
+  min-height: 100vh;
+  padding: var(--space-8) var(--space-4);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  background: var(--bg-primary);
+}
+
+.admin-container {
+  background: var(--bg-card);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-2xl);
+  max-width: 560px;
+  width: 100%;
+  overflow: hidden;
+}
+
+.admin-header {
+  padding: var(--space-8);
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.admin-title {
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-1) 0;
+}
+
+.admin-subtitle {
+  color: var(--color-text-secondary);
+  margin: 0;
+  font-size: var(--font-size-sm);
+}
+
+.admin-body {
+  padding: var(--space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.admin-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.admin-label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.admin-row {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.admin-input,
+.admin-select {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-base);
+  font-family: var(--font-sans);
+  color: var(--color-text-primary);
+  background: var(--bg-primary);
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+}
+
+.admin-input:focus,
+.admin-select:focus {
+  outline: none;
+  border-color: #1e40af;
+  box-shadow: 0 0 0 3px rgba(30, 64, 175, 0.1);
+}
+
+.admin-row .admin-input {
+  flex: 1;
+}
+
+.admin-btn {
+  padding: var(--space-3) var(--space-6);
+  border: none;
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-base);
+  font-family: var(--font-sans);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+  white-space: nowrap;
+}
+
+.admin-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.admin-btn-primary {
+  background: #1e40af;
+  color: white;
+}
+
+.admin-btn-primary:not(:disabled):hover {
+  background: #1e3a8a;
+}
+
+.admin-btn-secondary {
+  background: var(--bg-tertiary, #f1f5f9);
+  color: var(--color-text-primary);
+  border: 1px solid var(--border-primary);
+}
+
+.admin-btn-secondary:not(:disabled):hover {
+  background: var(--border-primary);
+}
+
+.admin-user-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.admin-user-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.admin-user-item:last-child {
+  border-bottom: none;
+}
+
+.admin-user-name {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+}
+
+.admin-badge {
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: 600;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-full, 9999px);
+}
+
+.badge-ok {
+  background: rgba(34, 197, 94, 0.12);
+  color: #15803d;
+}
+
+.badge-missing {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.admin-loading {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  margin: 0;
+}
+
+.admin-error {
+  color: #b91c1c;
+  font-size: var(--font-size-sm);
+  margin: 0;
+}
+
+.admin-success {
+  color: #15803d;
+  font-size: var(--font-size-sm);
+  margin: 0;
+}

--- a/frontend/src/AdminPasswords.tsx
+++ b/frontend/src/AdminPasswords.tsx
@@ -8,7 +8,8 @@ interface UserPasswordStatus {
 }
 
 function AdminPasswords() {
-  const isAdminUser = localStorage.getItem("user_role") === "Admin";
+  // null = still checking, true = confirmed Admin session, false = use secret form
+  const [sessionIsAdmin, setSessionIsAdmin] = useState<boolean | null>(null);
 
   const [adminSecret, setAdminSecret] = useState("");
   const [users, setUsers] = useState<UserPasswordStatus[] | null>(null);
@@ -20,8 +21,30 @@ function AdminPasswords() {
   const [isLoading, setIsLoading] = useState(false);
   const [isSetting, setIsSetting] = useState(false);
 
+  // On mount: validate the server session before trusting localStorage
+  useEffect(() => {
+    const localRole = localStorage.getItem("user_role");
+    if (localRole !== "Admin") {
+      setSessionIsAdmin(false);
+      return;
+    }
+    // Verify the session is still live before relying on it
+    apiGet("/api/admin/passwords-status")
+      .then(async (res) => {
+        if (res.ok) {
+          const data = await res.json();
+          setSessionIsAdmin(true);
+          setUsers(data.users);
+        } else {
+          // Session gone or role changed — fall back to the secret form
+          setSessionIsAdmin(false);
+        }
+      })
+      .catch(() => setSessionIsAdmin(false));
+  }, []);
+
   const extraHeaders = (secret: string): Record<string, string> =>
-    isAdminUser ? {} : { "X-Admin-Secret": secret };
+    sessionIsAdmin ? {} : { "X-Admin-Secret": secret };
 
   const fetchUsers = async (secret: string) => {
     setIsLoading(true);
@@ -48,16 +71,8 @@ function AdminPasswords() {
     }
   };
 
-  // Auto-load when an Admin-role user visits the page
-  useEffect(() => {
-    if (isAdminUser) {
-      fetchUsers("");
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const loadUsers = () => {
-    if (!isAdminUser && !adminSecret) {
+    if (!sessionIsAdmin && !adminSecret) {
       setLoadError("Admin secret is required.");
       return;
     }
@@ -102,6 +117,18 @@ function AdminPasswords() {
     }
   };
 
+  if (sessionIsAdmin === null) {
+    return (
+      <div className="admin-page">
+        <div className="admin-container">
+          <div className="admin-body">
+            <p className="admin-loading">Verifying session…</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="admin-page">
       <div className="admin-container">
@@ -111,8 +138,8 @@ function AdminPasswords() {
         </div>
 
         <div className="admin-body">
-          {/* Secret + Load — hidden for logged-in Admin users */}
-          {!isAdminUser && (
+          {/* Secret + Load — only shown when not using an Admin session */}
+          {!sessionIsAdmin && (
             <div className="admin-section">
               <label className="admin-label">Admin Secret</label>
               <div className="admin-row">
@@ -134,13 +161,6 @@ function AdminPasswords() {
               </div>
               {loadError && <p className="admin-error">{loadError}</p>}
             </div>
-          )}
-
-          {isAdminUser && isLoading && (
-            <p className="admin-loading">Loading users...</p>
-          )}
-          {isAdminUser && loadError && (
-            <p className="admin-error">{loadError}</p>
           )}
 
           {/* User status list */}

--- a/frontend/src/AdminPasswords.tsx
+++ b/frontend/src/AdminPasswords.tsx
@@ -1,0 +1,202 @@
+import { useState, useEffect } from "react";
+import { apiGet, apiPost } from "../api";
+import "./AdminPasswords.css";
+
+interface UserPasswordStatus {
+  name: string;
+  has_password: boolean;
+}
+
+function AdminPasswords() {
+  const isAdminUser = localStorage.getItem("user_role") === "Admin";
+
+  const [adminSecret, setAdminSecret] = useState("");
+  const [users, setUsers] = useState<UserPasswordStatus[] | null>(null);
+  const [selectedUser, setSelectedUser] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [loadError, setLoadError] = useState("");
+  const [setError, setSetError] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSetting, setIsSetting] = useState(false);
+
+  const extraHeaders = (secret: string): Record<string, string> =>
+    isAdminUser ? {} : { "X-Admin-Secret": secret };
+
+  const fetchUsers = async (secret: string) => {
+    setIsLoading(true);
+    setLoadError("");
+    setSuccessMessage("");
+    try {
+      const response = await apiGet("/api/admin/passwords-status", {
+        headers: extraHeaders(secret),
+      });
+      if (response.status === 403) {
+        setLoadError("Unauthorized. Check your admin secret.");
+        return;
+      }
+      if (!response.ok) {
+        setLoadError("Failed to load users.");
+        return;
+      }
+      const data = await response.json();
+      setUsers(data.users);
+    } catch {
+      setLoadError("Network error. Is the server running?");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Auto-load when an Admin-role user visits the page
+  useEffect(() => {
+    if (isAdminUser) {
+      fetchUsers("");
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const loadUsers = () => {
+    if (!isAdminUser && !adminSecret) {
+      setLoadError("Admin secret is required.");
+      return;
+    }
+    fetchUsers(adminSecret);
+  };
+
+  const handleSetPassword = async () => {
+    if (!selectedUser || !newPassword) {
+      setSetError("Select a user and enter a password.");
+      return;
+    }
+    if (newPassword.length < 8) {
+      setSetError("Password must be at least 8 characters.");
+      return;
+    }
+    setIsSetting(true);
+    setSetError("");
+    setSuccessMessage("");
+    try {
+      const response = await apiPost(
+        "/api/admin/set-password",
+        { user_name: selectedUser, password: newPassword },
+        { headers: extraHeaders(adminSecret) }
+      );
+      if (response.status === 403) {
+        setSetError("Unauthorized. Check your admin secret.");
+        return;
+      }
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        setSetError((data as { error?: string }).error || "Failed to set password.");
+        return;
+      }
+      setSuccessMessage(`Password set for ${selectedUser}.`);
+      setNewPassword("");
+      setSelectedUser("");
+      await fetchUsers(adminSecret);
+    } catch {
+      setSetError("Network error. Is the server running?");
+    } finally {
+      setIsSetting(false);
+    }
+  };
+
+  return (
+    <div className="admin-page">
+      <div className="admin-container">
+        <div className="admin-header">
+          <h1 className="admin-title">Password Manager</h1>
+          <p className="admin-subtitle">Set passwords for users</p>
+        </div>
+
+        <div className="admin-body">
+          {/* Secret + Load — hidden for logged-in Admin users */}
+          {!isAdminUser && (
+            <div className="admin-section">
+              <label className="admin-label">Admin Secret</label>
+              <div className="admin-row">
+                <input
+                  className="admin-input"
+                  type="password"
+                  value={adminSecret}
+                  onChange={(e) => setAdminSecret(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && loadUsers()}
+                  placeholder="Enter ADMIN_SECRET"
+                />
+                <button
+                  className="admin-btn admin-btn-secondary"
+                  onClick={loadUsers}
+                  disabled={isLoading}
+                >
+                  {isLoading ? "Loading..." : "Load Users"}
+                </button>
+              </div>
+              {loadError && <p className="admin-error">{loadError}</p>}
+            </div>
+          )}
+
+          {isAdminUser && isLoading && (
+            <p className="admin-loading">Loading users...</p>
+          )}
+          {isAdminUser && loadError && (
+            <p className="admin-error">{loadError}</p>
+          )}
+
+          {/* User status list */}
+          {users !== null && (
+            <>
+              <div className="admin-section">
+                <label className="admin-label">User Status</label>
+                <ul className="admin-user-list">
+                  {users.map((u) => (
+                    <li key={u.name} className="admin-user-item">
+                      <span className="admin-user-name">{u.name}</span>
+                      <span className={`admin-badge ${u.has_password ? "badge-ok" : "badge-missing"}`}>
+                        {u.has_password ? "Password set" : "No password"}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Set password form */}
+              <div className="admin-section">
+                <label className="admin-label">Set Password</label>
+                <select
+                  className="admin-select"
+                  value={selectedUser}
+                  onChange={(e) => { setSelectedUser(e.target.value); setSetError(""); }}
+                >
+                  <option value="">Select user...</option>
+                  {users.map((u) => (
+                    <option key={u.name} value={u.name}>{u.name}</option>
+                  ))}
+                </select>
+                <input
+                  className="admin-input"
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => { setNewPassword(e.target.value); setSetError(""); }}
+                  onKeyDown={(e) => e.key === "Enter" && handleSetPassword()}
+                  placeholder="New password (min 8 characters)"
+                />
+                {setError && <p className="admin-error">{setError}</p>}
+                {successMessage && <p className="admin-success">{successMessage}</p>}
+                <button
+                  className="admin-btn admin-btn-primary"
+                  onClick={handleSetPassword}
+                  disabled={isSetting || !selectedUser || !newPassword}
+                >
+                  {isSetting ? "Saving..." : "Set Password"}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AdminPasswords;

--- a/frontend/src/AdminPasswords.tsx
+++ b/frontend/src/AdminPasswords.tsx
@@ -106,10 +106,11 @@ function AdminPasswords() {
         setSetError((data as { error?: string }).error || "Failed to set password.");
         return;
       }
-      setSuccessMessage(`Password set for ${selectedUser}.`);
+      const savedUser = selectedUser;
       setNewPassword("");
       setSelectedUser("");
       await fetchUsers(adminSecret);
+      setSuccessMessage(`Password set for ${savedUser}.`);
     } catch {
       setSetError("Network error. Is the server running?");
     } finally {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import SimpleTest from "./SimpleTest";
 import DevoFeedbackEdit from "./DevoFeedbackEdit";
 import DutiesPage from "./DutiesPage";
 import Sections from "./Sections";
+import AdminPasswords from "./AdminPasswords";
 
 
 function App() {
@@ -18,6 +19,7 @@ function App() {
       <Route path="/duties" element={<DutiesPage />} />
       <Route path="/sections" element={<Sections />} />
       <Route path="/test" element={<SimpleTest />} />
+      <Route path="/admin/passwords" element={<AdminPasswords />} />
     </Routes>
   );
 }

--- a/frontend/src/Login.css
+++ b/frontend/src/Login.css
@@ -201,6 +201,35 @@
   transform: translateY(-50%) rotate(180deg);
 }
 
+/* ── Password input ─────────────────────────────────────────────────────── */
+
+.password-input {
+  width: 100%;
+  padding: var(--space-4);
+  border: 2px solid #f472b6;
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-base);
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  color: var(--color-text-primary);
+  background: white;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-sizing: border-box;
+}
+
+.password-input:focus {
+  outline: none;
+  border-color: #1e40af;
+  box-shadow: 0 0 0 3px rgba(30, 64, 175, 0.1);
+  transform: scale(1.002);
+}
+
+.password-input:disabled {
+  background: rgba(148, 163, 184, 0.1);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 /* ── Login button ───────────────────────────────────────────────────────── */
 
 .form-actions {

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -6,6 +6,7 @@ import "./Login.css";
 function Login() {
   const [users, setUsers] = useState<string[]>([]);
   const [selectedUser, setSelectedUser] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingUsers, setIsLoadingUsers] = useState(true);
   const [error, setError] = useState<string>("");
@@ -43,12 +44,16 @@ function Login() {
       setError("Please select a user!");
       return;
     }
+    if (!password) {
+      setError("Please enter your password.");
+      return;
+    }
 
     setIsLoading(true);
     setError("");
 
     try {
-      const response = await login(selectedUser);
+      const response = await login(selectedUser, password);
 
       if (!response.ok) {
         throw new Error(`Server error: ${response.status}`);
@@ -111,7 +116,7 @@ function Login() {
               <span className="label-icon">👤</span>
               Choose User
             </label>
-            
+
             {isLoadingUsers ? (
               <div className="loading-container">
                 <div className="loading-spinner"></div>
@@ -124,6 +129,7 @@ function Login() {
                   value={selectedUser}
                   onChange={(e) => {
                     setSelectedUser(e.target.value);
+                    setPassword("");
                     setError("");
                   }}
                   disabled={isLoading}
@@ -144,11 +150,33 @@ function Login() {
             )}
           </div>
 
+          {selectedUser && (
+            <div className="form-group">
+              <label className="form-label">
+                <span className="label-icon">🔒</span>
+                Password
+              </label>
+              <input
+                className="password-input"
+                type="password"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  setError("");
+                }}
+                onKeyDown={(e) => e.key === "Enter" && handleLogin()}
+                placeholder="Enter your password"
+                disabled={isLoading}
+                autoFocus
+              />
+            </div>
+          )}
+
           <div className="form-actions">
             <button
               className="login-btn"
               onClick={handleLogin}
-              disabled={!selectedUser || isLoading || isLoadingUsers}
+              disabled={!selectedUser || !password || isLoading || isLoadingUsers}
             >
               {isLoading ? (
                 <>

--- a/frontend/src/__tests__/AdminPasswords.test.tsx
+++ b/frontend/src/__tests__/AdminPasswords.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AdminPasswords from '../AdminPasswords';
+
+function renderAdminPasswords() {
+  return render(<AdminPasswords />);
+}
+
+const USER_STATUS = [
+  { name: 'Alice', has_password: true },
+  { name: 'Bob', has_password: false },
+];
+
+function mockStatusOk() {
+  vi.mocked(fetch).mockResolvedValueOnce(
+    new Response(JSON.stringify({ users: USER_STATUS }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+}
+
+function mock403() {
+  vi.mocked(fetch).mockResolvedValueOnce(new Response('{"error":"Unauthorized"}', { status: 403 }));
+}
+
+function mockSetPasswordOk(userName: string) {
+  vi.mocked(fetch).mockResolvedValueOnce(
+    new Response(JSON.stringify({ ok: true, user_name: userName }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+}
+
+describe('AdminPasswords — session validation on mount', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('shows a verifying state while the session probe is in flight', async () => {
+    localStorage.setItem('user_role', 'Admin');
+    vi.mocked(fetch).mockReturnValueOnce(new Promise(() => {})); // never resolves
+    renderAdminPasswords();
+    expect(screen.getByText(/verifying session/i)).toBeInTheDocument();
+  });
+
+  it('skips the probe and shows secret form when user_role is not Admin', async () => {
+    localStorage.setItem('user_role', 'Team Member');
+    renderAdminPasswords();
+    await waitFor(() => expect(screen.getByPlaceholderText(/enter admin_secret/i)).toBeInTheDocument());
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows user list without secret form when session probe succeeds', async () => {
+    localStorage.setItem('user_role', 'Admin');
+    mockStatusOk();
+    renderAdminPasswords();
+    await waitFor(() => expect(screen.getByText('Password set')).toBeInTheDocument());
+    expect(screen.getByText('No password')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/enter admin_secret/i)).not.toBeInTheDocument();
+  });
+
+  it('falls back to secret form when session probe returns 403', async () => {
+    localStorage.setItem('user_role', 'Admin');
+    mock403();
+    renderAdminPasswords();
+    await waitFor(() => expect(screen.getByPlaceholderText(/enter admin_secret/i)).toBeInTheDocument());
+  });
+});
+
+describe('AdminPasswords — secret form', () => {
+  beforeEach(() => {
+    localStorage.clear(); // no Admin role → goes straight to secret form
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('shows an error when Load Users is clicked with an empty secret', async () => {
+    renderAdminPasswords();
+    await waitFor(() => screen.getByRole('button', { name: /load users/i }));
+    fireEvent.click(screen.getByRole('button', { name: /load users/i }));
+    expect(screen.getByText(/admin secret is required/i)).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('renders the user list after a successful load', async () => {
+    mockStatusOk();
+    renderAdminPasswords();
+    await waitFor(() => screen.getByPlaceholderText(/enter admin_secret/i));
+    await userEvent.type(screen.getByPlaceholderText(/enter admin_secret/i), 'mysecret');
+    fireEvent.click(screen.getByRole('button', { name: /load users/i }));
+    await waitFor(() => expect(screen.getByText('Password set')).toBeInTheDocument());
+    expect(screen.getByText('No password')).toBeInTheDocument();
+  });
+
+  it('shows an error on 403', async () => {
+    mock403();
+    renderAdminPasswords();
+    await waitFor(() => screen.getByPlaceholderText(/enter admin_secret/i));
+    await userEvent.type(screen.getByPlaceholderText(/enter admin_secret/i), 'wrongsecret');
+    fireEvent.click(screen.getByRole('button', { name: /load users/i }));
+    await waitFor(() => expect(screen.getByText(/unauthorized/i)).toBeInTheDocument());
+  });
+
+  it('shows a network error message on fetch failure', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+    renderAdminPasswords();
+    await waitFor(() => screen.getByPlaceholderText(/enter admin_secret/i));
+    await userEvent.type(screen.getByPlaceholderText(/enter admin_secret/i), 'mysecret');
+    fireEvent.click(screen.getByRole('button', { name: /load users/i }));
+    await waitFor(() => expect(screen.getByText(/network error/i)).toBeInTheDocument());
+  });
+});
+
+describe('AdminPasswords — set password form', () => {
+  beforeEach(async () => {
+    localStorage.clear();
+    vi.stubGlobal('fetch', vi.fn());
+    // Render with the session-probe path: Admin in localStorage, probe succeeds
+    localStorage.setItem('user_role', 'Admin');
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  async function renderWithUsers() {
+    mockStatusOk();
+    renderAdminPasswords();
+    await waitFor(() => expect(screen.getByText('Password set')).toBeInTheDocument());
+  }
+
+  it('Set Password button is disabled until both a user and password are provided', async () => {
+    await renderWithUsers();
+    expect(screen.getByRole('button', { name: /set password/i })).toBeDisabled();
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'Bob');
+    expect(screen.getByRole('button', { name: /set password/i })).toBeDisabled();
+    await userEvent.type(screen.getByPlaceholderText(/new password/i), 'validpassword');
+    expect(screen.getByRole('button', { name: /set password/i })).not.toBeDisabled();
+  });
+
+  it('shows an error when the password is too short', async () => {
+    await renderWithUsers();
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'Bob');
+    await userEvent.type(screen.getByPlaceholderText(/new password/i), 'short');
+    await userEvent.click(screen.getByRole('button', { name: /set password/i }));
+    await waitFor(() => expect(screen.getByText(/at least 8 characters/i)).toBeInTheDocument());
+  });
+
+  it('shows success and refreshes the list on a successful password set', async () => {
+    await renderWithUsers();
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'Bob');
+    await userEvent.type(screen.getByPlaceholderText(/new password/i), 'validpassword');
+    mockSetPasswordOk('Bob');
+    mockStatusOk(); // refresh after set
+    await userEvent.click(screen.getByRole('button', { name: /set password/i }));
+    await waitFor(() => expect(screen.getByText(/password set for bob/i)).toBeInTheDocument());
+  });
+
+  it('shows an error on 403 from set-password', async () => {
+    await renderWithUsers();
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'Alice');
+    await userEvent.type(screen.getByPlaceholderText(/new password/i), 'validpassword');
+    mock403();
+    await userEvent.click(screen.getByRole('button', { name: /set password/i }));
+    await waitFor(() => expect(screen.getByText(/unauthorized/i)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/__tests__/Login.test.tsx
+++ b/frontend/src/__tests__/Login.test.tsx
@@ -107,6 +107,18 @@ describe('Login', () => {
     expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
   });
 
+  it('clears the password field when a different user is selected', async () => {
+    mockFetchUsers();
+    renderLogin();
+    await waitFor(() => screen.getByRole('combobox'));
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'Alice');
+    await userEvent.type(screen.getByPlaceholderText(/enter your password/i), 'secret123');
+    expect(screen.getByPlaceholderText(/enter your password/i)).toHaveValue('secret123');
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'Bob');
+    expect(screen.getByPlaceholderText(/enter your password/i)).toHaveValue('');
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
+  });
+
   it('stores auth data and navigates to / on successful login', async () => {
     mockFetchUsers();
     renderLogin();

--- a/frontend/src/__tests__/Login.test.tsx
+++ b/frontend/src/__tests__/Login.test.tsx
@@ -90,11 +90,20 @@ describe('Login', () => {
     expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
   });
 
-  it('enables the Continue button after selecting a user', async () => {
+  it('keeps Continue disabled after selecting a user but before entering a password', async () => {
     mockFetchUsers();
     renderLogin();
     await waitFor(() => screen.getByRole('combobox'));
     await userEvent.selectOptions(screen.getByRole('combobox'), 'Alice');
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
+  });
+
+  it('enables the Continue button after selecting a user and entering a password', async () => {
+    mockFetchUsers();
+    renderLogin();
+    await waitFor(() => screen.getByRole('combobox'));
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'Alice');
+    await userEvent.type(screen.getByPlaceholderText(/enter your password/i), 'secret123');
     expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
   });
 
@@ -104,6 +113,7 @@ describe('Login', () => {
     await waitFor(() => screen.getByRole('combobox'));
 
     await userEvent.selectOptions(screen.getByRole('combobox'), 'Bob');
+    await userEvent.type(screen.getByPlaceholderText(/enter your password/i), 'secret123');
     mockLoginSuccess('Bob');
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
 
@@ -121,6 +131,7 @@ describe('Login', () => {
     await waitFor(() => screen.getByRole('combobox'));
 
     await userEvent.selectOptions(screen.getByRole('combobox'), 'Alice');
+    await userEvent.type(screen.getByPlaceholderText(/enter your password/i), 'secret123');
     vi.mocked(fetch).mockResolvedValueOnce(new Response('', { status: 500 }));
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
 

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -121,19 +121,20 @@ describe('login', () => {
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  it('POSTs to /api/auth/login with the supplied username', async () => {
+  it('POSTs to /api/auth/login with the supplied username and password', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response('{}'));
-    await login('Alice');
+    await login('Alice', 'secret123');
     const [url, options] = vi.mocked(fetch).mock.calls[0];
     expect(url).toBe('/api/auth/login');
     expect(options?.method).toBe('POST');
     const body = JSON.parse(options?.body as string);
     expect(body.user_name).toBe('Alice');
+    expect(body.password).toBe('secret123');
   });
 
   it('sends credentials: include so the session cookie is accepted', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response('{}'));
-    await login('Alice');
+    await login('Alice', 'secret123');
     const [, options] = vi.mocked(fetch).mock.calls[0];
     expect(options?.credentials).toBe('include');
   });

--- a/frontend/tests/e2e/login.spec.ts
+++ b/frontend/tests/e2e/login.spec.ts
@@ -25,10 +25,13 @@ test('login page visual snapshot', async ({ page }) => {
   await expect(page).toHaveScreenshot('login-page.png', { fullPage: true, maxDiffPixels: 200 });
 });
 
-test('selecting a user enables the continue button', async ({ page }) => {
+test('selecting a user and entering a password enables the continue button', async ({ page }) => {
   await page.goto('/login');
   await page.waitForSelector('select.user-select');
   await page.selectOption('select.user-select', 'Alice');
+  // Button stays disabled until a password is also entered
+  await expect(page.getByRole('button', { name: /continue/i })).toBeDisabled();
+  await page.fill('input[type="password"]', 'secret123');
   await expect(page.getByRole('button', { name: /continue/i })).toBeEnabled();
 });
 


### PR DESCRIPTION
  ### Summary
  - The app previously had no password protection — anyone could log in as any user by selecting a name from a dropdown. This adds bcrypt-hashed passwords to every account.
  - Passwords are admin-managed only: users cannot set or change their own passwords. An admin can manage all passwords via a new `/admin/passwords` page, protected by either an `ADMIN_SECRET` env var or an
  active session with the `Admin` role.
  - Users with no password set are locked out immediately, so all passwords must be assigned before deploying.

  ### Changes
  **Database**
  - New column: `ALTER TABLE users ADD COLUMN password_hash VARCHAR(255) NULL;` (must be run manually on Supabase before deploying)

  **Backend**
  - `requirements.txt`: added `bcrypt==4.3.0`
  - `utils.py` — `authenticate_user()` now accepts a `password` argument, fetches `password_hash` from the DB, and verifies with `bcrypt.checkpw()`; a `NULL` hash or wrong password both raise
  `AuthenticationError("Invalid credentials")`
  - `routes/users.py` — `POST /api/auth/login` now requires a `password` field in the request body; stores `user_role` in the Flask session (was previously absent)
  - `routes/admin.py` — two new endpoints:
    - `GET /api/admin/passwords-status`: returns all users with a `has_password` boolean
    - `POST /api/admin/set-password`: hashes and writes a password for a named user
    - `_is_authorized_admin()` helper: accepts a session Admin role (fast path), DB role lookup for stale pre-migration sessions, or a matching `X-Admin-Secret` header

  **Frontend**
  - `api.ts` — `login()` now takes `(userName, password)`
  - `Login.tsx` — password `<input>` appears after a user is selected; Continue button requires both fields; Enter key submits
  - `Login.css` — `.password-input` styles matching the existing select field
  - `AdminPasswords.tsx` + `AdminPasswords.css` — new page at `/admin/passwords`; auto-loads for Admin-role users, shows secret input for others; displays per-user password status and a set-password form
  - `App.tsx` — route added for `/admin/passwords`

  **Tests**
  - Updated unit tests (`api.test.ts`, `Login.test.tsx`, `test_users.py`, `test_utils.py`) to supply passwords and cover new failure modes (missing password, wrong password, null hash)
  - Updated E2E test (`login.spec.ts`) to fill the password field before asserting the Continue button is enabled

  ### Test plan
  - [ ] Run `ALTER TABLE users ADD COLUMN password_hash VARCHAR(255) NULL;` on the database
  - [ ] Set `ADMIN_SECRET` in `.env`; confirm it appears in the container environment (`docker-compose up`)
  - [ ] Navigate to `/admin/passwords`, enter the secret, load users — all should show "No password"
  - [ ] Set a password for one user; confirm the badge changes to "Password set"
  - [ ] Log in as that user with the correct password — should succeed and land on home
  - [ ] Log in with the wrong password — should show an error, stay on login
  - [ ] Attempt to log in as a user with no password set — should be rejected
  - [ ] Log in as the Admin-role user; navigate to `/admin/passwords` — page should auto-load without requiring the secret
  - [ ] `npm run test:run` — 107 frontend unit tests pass
  - [ ] `PYTHONPATH=. pytest backend/tests/` — 338 backend tests pass
  - [ ] `npx playwright test` — all E2E tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-based login required for sign-in.
  * Admin Passwords page: view which accounts have passwords and set/reset user passwords (supports admin-session or admin-secret access).

* **Behavior Changes**
  * Session now records user role for session-aware UI and admin checks.
  * Login flow and UI updated to require and transmit a password.

* **Tests**
  * Expanded unit, integration, and e2e tests for login and admin/password workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->