### PR TITLE
refactor(#160): introduce CACHE_REGISTRY and fix duty cache key design

### DIFF
--- a/backend/bcssm_backend/cache_utils.py
+++ b/backend/bcssm_backend/cache_utils.py
@@ -28,7 +28,7 @@ class CacheEntry:
 CACHE_REGISTRY: dict[str, CacheEntry] = {
     "users:all:list":                    CacheEntry(ttl=900,  group="users",    on_error=[]),
     "user:duty:{name}:{date}":           CacheEntry(ttl=600,  group="duties"),
-    "duties:today:{day}:{cycle}:{name}": CacheEntry(ttl=1800, group="duties",   error_ttl=60, on_error=[]),
+    "duties:today:day{day}:cycle{cycle}:user{name}": CacheEntry(ttl=1800, group="duties",   error_ttl=60, on_error=[]),
     "duties:schedule:14day:{date}":      CacheEntry(ttl=7200, group="duties",   error_ttl=60, on_error=[]),
     "sections:all:list":                 CacheEntry(ttl=3600, group="sections", error_ttl=60),
     "users:section:{name}":              CacheEntry(ttl=1800, group="users",    error_ttl=60),

--- a/backend/bcssm_backend/cache_utils.py
+++ b/backend/bcssm_backend/cache_utils.py
@@ -1,5 +1,7 @@
 import copy
+from dataclasses import dataclass, field
 from functools import wraps
+from typing import Any
 from sqlalchemy.exc import SQLAlchemyError
 import logging
 
@@ -13,15 +15,60 @@ def get_ttl_registry():
     return dict(_ttl_registry)
 
 
-def cached_result(key_fn, ttl, error_ttl=None, on_error=_RAISE, cache=None):
+@dataclass
+class CacheEntry:
+    ttl: int
+    group: str
+    error_ttl: int | None = None
+    on_error: Any = field(default_factory=lambda: _RAISE)
+
+
+# Single source of truth for cache key templates, TTLs, and invalidation groups.
+# Used by cached_result (TTL lookup) and clear_group (bulk invalidation in #165).
+CACHE_REGISTRY: dict[str, CacheEntry] = {
+    "users:all:list":                    CacheEntry(ttl=900,  group="users",    on_error=[]),
+    "user:duty:{name}:{date}":           CacheEntry(ttl=600,  group="duties"),
+    "duties:today:{day}:{cycle}:{name}": CacheEntry(ttl=1800, group="duties",   error_ttl=60, on_error=[]),
+    "duties:schedule:14day:{date}":      CacheEntry(ttl=7200, group="duties",   error_ttl=60, on_error=[]),
+    "sections:all:list":                 CacheEntry(ttl=3600, group="sections", error_ttl=60),
+    "users:section:{name}":              CacheEntry(ttl=1800, group="users",    error_ttl=60),
+    "users:section:{name}:detailed":     CacheEntry(ttl=1800, group="users",    error_ttl=60),
+    "feedback:dates:all":                CacheEntry(ttl=7200, group="feedback", error_ttl=60),
+    "sections:with_users:all_v6":        CacheEntry(ttl=1800, group="sections", error_ttl=60),
+    "sections:statistics:summary":       CacheEntry(ttl=3600, group="sections", error_ttl=60),
+}
+
+
+def cached_result(key_fn, ttl=None, error_ttl=None, on_error=_RAISE, cache=None,
+                  registry_key=None):
     """
     key_fn: str for static keys, or callable(*args, **kwargs) -> str for dynamic keys
-    ttl: success cache TTL (seconds)
-    error_ttl: error cache TTL (seconds); None = don't cache on error
+    ttl: success cache TTL (seconds); if None, looked up from CACHE_REGISTRY
+    error_ttl: error cache TTL (seconds); if None, looked up from CACHE_REGISTRY
     on_error: value or callable(exc)->value returned on SQLAlchemyError;
               default _RAISE re-raises the exception
     cache: injectable cache instance for testing; defaults to backend.globals.cache
+    registry_key: CACHE_REGISTRY template to use for TTL lookup when key_fn is callable
     """
+    # Resolve TTL and error_ttl from registry when not explicitly provided
+    _registry_key = registry_key if registry_key is not None else (
+        key_fn if isinstance(key_fn, str) else None
+    )
+    if _registry_key is not None:
+        entry = CACHE_REGISTRY.get(_registry_key)
+        if entry is not None:
+            if ttl is None:
+                ttl = entry.ttl
+            if error_ttl is None:
+                error_ttl = entry.error_ttl
+            if on_error is _RAISE and entry.on_error is not _RAISE:
+                on_error = entry.on_error
+
+    if ttl is None:
+        raise ValueError(
+            f"No TTL found for '{_registry_key}' — add it to CACHE_REGISTRY or pass ttl= explicitly"
+        )
+
     def decorator(func):
         _ttl_registry[func.__name__] = ttl
 

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -147,7 +147,7 @@ def _todays_duties_key(user_name):
     return f'duties:today:day{day}:cycle{cycle}:user{user_name}'
 
 
-@cached_result(_todays_duties_key, registry_key='duties:today:{day}:{cycle}:{name}', on_error=[])
+@cached_result(_todays_duties_key, registry_key='duties:today:day{day}:cycle{cycle}:user{name}', on_error=[])
 def get_todays_duties(user_name):
     current_day = (datetime.now().weekday() + 1) % 7
     current_cycle = get_current_cycle_week()

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -76,7 +76,7 @@ def execute_query(query, params=None, silent=False):
         )
         raise
 
-@cached_result('users:all:list', 900, on_error=[])
+@cached_result('users:all:list', on_error=[])
 def get_all_users():
     query = """
     SELECT
@@ -99,12 +99,10 @@ def get_all_users():
     return [row[0] for row in rows]
 
 def _user_duty_key(user_name):
-    day = (datetime.now().weekday() + 1) % 7
-    cycle = get_current_cycle_week()
-    return f'user:duty:{user_name}:day{day}:cycle{cycle}'
+    return f'user:duty:{user_name}:{datetime.now().date()}'
 
 
-@cached_result(_user_duty_key, 600)
+@cached_result(_user_duty_key, registry_key='user:duty:{name}:{date}')
 def get_user_duty(user_name):
     current_day = (datetime.now().weekday() + 1) % 7
     current_cycle = get_current_cycle_week()
@@ -149,7 +147,7 @@ def _todays_duties_key(user_name):
     return f'duties:today:day{day}:cycle{cycle}:user{user_name}'
 
 
-@cached_result(_todays_duties_key, 1800, error_ttl=60, on_error=[])
+@cached_result(_todays_duties_key, registry_key='duties:today:{day}:{cycle}:{name}', on_error=[])
 def get_todays_duties(user_name):
     current_day = (datetime.now().weekday() + 1) % 7
     current_cycle = get_current_cycle_week()
@@ -203,7 +201,7 @@ def _duty_schedule_key():
     return f'duties:schedule:14day:{datetime.now().date()}'
 
 
-@cached_result(_duty_schedule_key, 7200, error_ttl=60, on_error=[])
+@cached_result(_duty_schedule_key, registry_key='duties:schedule:14day:{date}', on_error=[])
 def get_duty_schedule():
     start_date = CYCLE_ANCHOR
 
@@ -287,7 +285,7 @@ def get_duty_schedule():
     return schedule
 
 
-@cached_result('sections:all:list', 3600, error_ttl=60,
+@cached_result('sections:all:list',
                on_error=lambda e: {"error": f"Failed to fetch sections: {e}"})
 def get_all_sections():
     query = """
@@ -298,7 +296,8 @@ def get_all_sections():
     result = execute_readonly_query(query)
     return [row[0] for row in result]
 
-@cached_result(lambda section: f'users:section:{section}', 1800, error_ttl=60,
+@cached_result(lambda section: f'users:section:{section}',
+               registry_key='users:section:{name}',
                on_error=lambda e: {"error": f"Failed to fetch users by section: {e}"})
 def get_users_by_section(section):
     query = """
@@ -311,7 +310,7 @@ def get_users_by_section(section):
     result = execute_readonly_query(query, {"section": section})
     return [{"name": row[0], "role": row[1]} for row in result]
 
-@cached_result('feedback:dates:all', 7200, error_ttl=60,
+@cached_result('feedback:dates:all',
                on_error=lambda e: {"error": f"Failed to fetch feedback dates: {e}"})
 def get_all_feedback_dates():
     query = """
@@ -415,7 +414,7 @@ def clear_all_cache():
     except RedisError as e:
         logger.warning("Failed to clear all caches: %s", e)
 
-@cached_result('sections:with_users:all_v6', 1800, error_ttl=60,
+@cached_result('sections:with_users:all_v6',
                on_error=lambda e: {"error": f"Failed to fetch sections with users: {e}"})
 def get_all_sections_with_users():
     # Optimized query using proper JOINs and leveraging indexes
@@ -475,7 +474,7 @@ def get_all_sections_with_users():
     sections_list.sort(key=lambda x: (x["display_order"], x["name"]))
     return sections_list
     
-@cached_result('sections:statistics:summary', 3600, error_ttl=60,
+@cached_result('sections:statistics:summary',
                on_error=lambda e: {"error": f"Failed to fetch section statistics: {e}"})
 def get_section_statistics():
     query = """
@@ -504,7 +503,8 @@ def get_section_statistics():
         for row in rows
     ]
 
-@cached_result(lambda section_name: f'users:section:{section_name}:detailed', 1800, error_ttl=60,
+@cached_result(lambda section_name: f'users:section:{section_name}:detailed',
+               registry_key='users:section:{name}:detailed',
                on_error=lambda e: {"error": f"Failed to fetch users by section: {e}"})
 def get_users_by_section_optimized(section_name):
     if section_name == "Unassigned":

--- a/backend/tests/test_cache_utils.py
+++ b/backend/tests/test_cache_utils.py
@@ -1,7 +1,8 @@
 import pytest
-from unittest.mock import MagicMock
+from datetime import date
+from unittest.mock import MagicMock, patch
 from sqlalchemy.exc import SQLAlchemyError
-from backend.bcssm_backend.cache_utils import cached_result, get_ttl_registry
+from backend.bcssm_backend.cache_utils import cached_result, get_ttl_registry, CACHE_REGISTRY
 
 
 def _make_cache():
@@ -188,3 +189,66 @@ def test_ttl_registry_records_decorated_functions():
     registry = get_ttl_registry()
     assert 'my_registered_fn' in registry
     assert registry['my_registered_fn'] == 999
+
+
+# ─── CACHE_REGISTRY ───────────────────────────────────────────────────────────
+
+def test_registry_lookup_sets_ttl_for_static_key():
+    fake_cache = _make_cache()
+
+    @cached_result('users:all:list', cache=fake_cache)
+    def fn():
+        return ['a']
+
+    fn()
+    fake_cache.set.assert_called_once_with('users:all:list', ['a'], timeout=900)
+
+
+def test_registry_lookup_via_registry_key_for_dynamic_key():
+    fake_cache = _make_cache()
+
+    @cached_result(lambda name: f'user:duty:{name}:2025-01-01',
+                   registry_key='user:duty:{name}:{date}', cache=fake_cache)
+    def fn(name):
+        return {'user': name}
+
+    fn('Alice')
+    _, kwargs = fake_cache.set.call_args
+    assert kwargs['timeout'] == 600
+
+
+def test_registry_missing_key_with_no_explicit_ttl_raises():
+    with pytest.raises(ValueError, match="CACHE_REGISTRY"):
+        @cached_result(lambda x: f'unknown:{x}', registry_key='unknown:{x}')
+        def fn(x):  # pragma: no cover
+            return x
+
+
+def test_all_registry_entries_have_valid_group():
+    valid_groups = {"users", "duties", "sections", "feedback"}
+    for key, entry in CACHE_REGISTRY.items():
+        assert entry.group in valid_groups, (
+            f"Registry entry '{key}' has unknown group '{entry.group}'"
+        )
+
+
+def test_all_registry_entries_have_positive_ttl():
+    for key, entry in CACHE_REGISTRY.items():
+        assert entry.ttl > 0, f"Registry entry '{key}' has non-positive ttl {entry.ttl}"
+        if entry.error_ttl is not None:
+            assert entry.error_ttl > 0, (
+                f"Registry entry '{key}' has non-positive error_ttl {entry.error_ttl}"
+            )
+
+
+# ─── Duty key design ──────────────────────────────────────────────────────────
+
+def test_user_duty_key_is_date_based():
+    from backend.bcssm_backend.utils import _user_duty_key
+    fixed_date = date(2025, 6, 16)
+    with patch('backend.bcssm_backend.utils.datetime') as mock_dt:
+        mock_dt.now.return_value.date.return_value = fixed_date
+        key = _user_duty_key('Alice')
+    assert key == f'user:duty:Alice:{fixed_date}'
+    assert 'day' not in key
+    assert 'cycle' not in key

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -53,10 +53,17 @@ def mock_db_session():
         yield sess
 
 # ─── 3) Utility to control "today" in date‐sensitive code ─────────────────────
+_FAKE_DATE = datetime(2025, 6, 16).date()
+
 class FakeDatetime:
+    today_date = _FAKE_DATE
+
     @classmethod
     def now(cls):
-        return SimpleNamespace(weekday=lambda: cls.today_weekday)
+        return SimpleNamespace(
+            weekday=lambda: cls.today_weekday,
+            date=lambda: cls.today_date,
+        )
 
 # ─── 4) Tests for get_all_users() ────────────────────────────────────────────
 def test_get_all_users_happy_path(mock_readonly, mock_cache):
@@ -142,14 +149,14 @@ def test_get_user_duty_valid_today_returns_expected(monkeypatch, mock_readonly, 
         "duty": "Lunch Duty"
     }
     
-    # Verify cache operations - day is now 3 instead of 2
-    cache_key_pattern = 'user:duty:Ivy:day3:cycle0'
+    # Verify cache operations — key is now date-based
+    cache_key_pattern = f'user:duty:Ivy:{_FAKE_DATE}'
     mock_cache.get.assert_called_once_with(cache_key_pattern)
     mock_cache.set.assert_called_once()
     cache_set_args = mock_cache.set.call_args
     assert cache_set_args[0][0] == cache_key_pattern
     assert cache_set_args[1]['timeout'] == 600
-    
+
     mock_readonly.assert_called_once()
     sql, params = mock_readonly.call_args[0]
     assert isinstance(params['day'], int)
@@ -178,8 +185,8 @@ def test_get_user_duty_cache_hit(monkeypatch, mock_readonly, mock_cache):
     # Assert
     assert result == cached_duty
     
-    # Verify cache was checked - day is now 3 instead of 2
-    mock_cache.get.assert_called_once_with('user:duty:Ivy:day3:cycle0')
+    # Verify cache was checked — key is now date-based
+    mock_cache.get.assert_called_once_with(f'user:duty:Ivy:{_FAKE_DATE}')
     # Verify DB was NOT queried
     mock_readonly.assert_not_called()
     # Verify cache was NOT set (already had data)


### PR DESCRIPTION
## Summary

- Adds `CacheEntry` dataclass and `CACHE_REGISTRY` in `cache_utils.py` — single source of truth for cache key templates, TTLs, and invalidation groups (unblocks #165)
- Extends `cached_result` with optional `registry_key` param so dynamic-key decorators can look up TTL from the registry
- All `@cached_result` usages in `utils.py` now omit explicit TTL params (registry provides them), removing duplication
- Fixes duty cache key: `user:duty:{name}:day{d}:cycle{c}` → `user:duty:{name}:{date}` — enables targeted clearing without `cache.clear()`

Closes #160.

## Test plan

- [x] `pytest backend/tests/` — 373 tests pass locally
- [x] Registry integrity tests: all entries have valid groups and positive TTLs
- [x] Key design test: `_user_duty_key('Alice')` returns `user:duty:Alice:2025-06-16` (date-based, no day/cycle)
- [x] Registry lookup test: `@cached_result('users:all:list')` uses TTL=900 from registry
- [x] Backward compat: `@cached_result('key', 999)` with explicit TTL still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized cache configuration with a registry-driven TTL and error-TTL resolution
  * Decorators now derive TTLs and error behavior from the registry; missing registry entries are validated and surface errors
  * Cache keys for user-duty and related utilities now include the current date for consistent, predictable caching

* **Tests**
  * Expanded coverage for registry validation, TTL resolution, and cache key format/behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->