### PR TITLE
Extract _build_schedule from get_duty_schedule, fix cache key bug

### DIFF
--- a/backend/bcssm_backend/cache_utils.py
+++ b/backend/bcssm_backend/cache_utils.py
@@ -29,7 +29,7 @@ CACHE_REGISTRY: dict[str, CacheEntry] = {
     "users:all:list":                    CacheEntry(ttl=900,  group="users",    on_error=[]),
     "user:duty:{name}:{date}":           CacheEntry(ttl=600,  group="duties"),
     "duties:today:{day}:{cycle}:{name}":              CacheEntry(ttl=1800, group="duties",   error_ttl=60, on_error=[]),
-    "duties:schedule:14day:{date}":      CacheEntry(ttl=7200, group="duties",   error_ttl=60, on_error=[]),
+    "duties:schedule:14day:anchor":      CacheEntry(ttl=7200, group="duties",   error_ttl=60, on_error=[]),
     "sections:all:list":                 CacheEntry(ttl=3600, group="sections", error_ttl=60),
     "users:section:{name}":              CacheEntry(ttl=1800, group="users",    error_ttl=60),
     "users:section:{name}:detailed":     CacheEntry(ttl=1800, group="users",    error_ttl=60),

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -199,31 +199,60 @@ def get_todays_duties(user_name):
         }
         for row in rows
     ]
-def _duty_schedule_key():
-    return f'duties:schedule:14day:{datetime.now().date()}'
+DUTY_SCHEDULE_CACHE_KEY = 'duties:schedule:14day:anchor'
 
 
-@cached_result(_duty_schedule_key, registry_key='duties:schedule:14day:{date}', on_error=[])
-def get_duty_schedule():
-    start_date = CYCLE_ANCHOR
+def _build_schedule(start_date: datetime, rows: list) -> list[dict]:
+    """Pure: builds the 14-day schedule response from an anchor date and raw DB rows.
 
-    # Pre-calculate all day/cycle combinations we need
-    day_cycle_combinations = []
+    start_date is always CYCLE_ANCHOR in production. Accepts it as a parameter
+    so tests can pass any anchor without patching the module global.
+    """
     date_to_info = {}
-
     for i in range(14):
         current_date = start_date + timedelta(days=i)
-        db_day = (current_date.weekday() + 1) % 7  # Adjust to Sunday=0
+        db_day = (current_date.weekday() + 1) % 7
         cycle_week = _cycle_week_for_date(current_date.date())
-        
-        day_cycle_combinations.append((db_day, cycle_week))
         date_to_info[current_date.date()] = {
-            "day": db_day, 
+            "day": db_day,
             "cycle_week": cycle_week,
-            "week_name": "Week A" if cycle_week == 0 else "Week B"
+            "week_name": "Week A" if cycle_week == 0 else "Week B",
         }
 
-    # Use a more efficient parameterized query
+    duty_lookup = defaultdict(list)
+    for row in rows:
+        day, cycle_week, duty_name, duty_description, team_name, team_members = row
+        duty_lookup[(day, cycle_week)].append({
+            "duty_name": duty_name,
+            "duty_description": duty_description,
+            "team_name": team_name,
+            "team_members": team_members or [],
+        })
+
+    schedule = []
+    for dt in sorted(date_to_info.keys()):
+        info = date_to_info[dt]
+        schedule.append({
+            "date": dt.strftime("%Y-%m-%d"),
+            "day_name": dt.strftime("%A"),
+            "week": info["week_name"],
+            "duties": duty_lookup.get((info["day"], info["cycle_week"]), []),
+        })
+    return schedule
+
+
+@cached_result(DUTY_SCHEDULE_CACHE_KEY, on_error=[])
+def get_duty_schedule():
+    combinations = [
+        (
+            ((CYCLE_ANCHOR + timedelta(days=i)).weekday() + 1) % 7,
+            _cycle_week_for_date((CYCLE_ANCHOR + timedelta(days=i)).date()),
+        )
+        for i in range(14)
+    ]
+    days = list({c[0] for c in combinations})
+    cycles = list({c[1] for c in combinations})
+
     query = '''
     SELECT
         ds.day,
@@ -249,42 +278,14 @@ def get_duty_schedule():
     JOIN duties d ON ds.duty_id = d.id
     JOIN duty_teams dt ON ds.duty_team_id = dt.id
     LEFT JOIN users u ON u.duty_team_id = dt.id
-    WHERE ds.day = ANY(:days) 
+    WHERE ds.day = ANY(:days)
         AND ds.cycle_week = ANY(:cycles)
     GROUP BY ds.day, ds.cycle_week, d.name, d.duty_description, dt.name, d.id
     ORDER BY ds.day, d.name;
     '''
 
-    days = list(set(combo[0] for combo in day_cycle_combinations))
-    cycles = list(set(combo[1] for combo in day_cycle_combinations))
     rows = execute_readonly_query(query, {"days": days, "cycles": cycles})
-
-    # Group duties by (day, cycle_week) combination
-    duty_lookup = defaultdict(list)
-    for row in rows:
-        day, cycle_week, duty_name, duty_description, team_name, team_members = row
-        duty = {
-            "duty_name": duty_name,
-            "duty_description": duty_description,
-            "team_name": team_name,
-            "team_members": team_members or []
-        }
-        duty_lookup[(day, cycle_week)].append(duty)
-
-    # Assemble final schedule
-    schedule = []
-    for dt in sorted(date_to_info.keys()):
-        info = date_to_info[dt]
-        duties_for_date = duty_lookup.get((info["day"], info["cycle_week"]), [])
-        
-        schedule.append({
-            "date": dt.strftime("%Y-%m-%d"),
-            "day_name": dt.strftime("%A"),
-            "week": info["week_name"],
-            "duties": duties_for_date
-        })
-
-    return schedule
+    return _build_schedule(CYCLE_ANCHOR, rows)
 
 
 @cached_result('sections:all:list',

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 CYCLE_ANCHOR = datetime(2026, 7, 4)
 
 @lru_cache(maxsize=2)
-def _cycle_week_for_date(target_date):
-    days_since_cycle_start = (target_date - CYCLE_ANCHOR.date()).days
+def _cycle_week_for_date(target_date, anchor=CYCLE_ANCHOR.date()):
+    days_since_cycle_start = (target_date - anchor).days
     return (days_since_cycle_start // 7) % 2
 
 def get_current_cycle_week():
@@ -212,7 +212,7 @@ def _build_schedule(start_date: datetime, rows: list) -> list[dict]:
     for i in range(14):
         current_date = start_date + timedelta(days=i)
         db_day = (current_date.weekday() + 1) % 7
-        cycle_week = _cycle_week_for_date(current_date.date())
+        cycle_week = _cycle_week_for_date(current_date.date(), anchor=start_date.date())
         date_to_info[current_date.date()] = {
             "day": db_day,
             "cycle_week": cycle_week,

--- a/backend/bcssm_backend/utils.py
+++ b/backend/bcssm_backend/utils.py
@@ -23,7 +23,9 @@ logger = logging.getLogger(__name__)
 CYCLE_ANCHOR = datetime(2026, 7, 4)
 
 @lru_cache(maxsize=2)
-def _cycle_week_for_date(target_date, anchor=CYCLE_ANCHOR.date()):
+def _cycle_week_for_date(target_date, anchor=None):
+    if anchor is None:
+        anchor = CYCLE_ANCHOR.date()
     days_since_cycle_start = (target_date - anchor).days
     return (days_since_cycle_start // 7) % 2
 

--- a/backend/tests/test_cache_utils.py
+++ b/backend/tests/test_cache_utils.py
@@ -383,7 +383,8 @@ def test_clear_group_duties_scans_all_three_patterns():
     fake_cache, mock_redis = _make_cache_with_redis()
     clear_group("duties", cache=fake_cache)
 
-    fake_cache.delete.assert_not_called()
+    # duties:schedule:14day:anchor is a static key — deleted directly, not via SCAN
+    fake_cache.delete.assert_called_once_with('duties:schedule:14day:anchor')
 
     patterns_scanned = {
         c.kwargs.get('match') or c.args[0]
@@ -391,7 +392,7 @@ def test_clear_group_duties_scans_all_three_patterns():
     }
     assert "user:duty:*" in patterns_scanned
     assert "duties:today:*" in patterns_scanned
-    assert "duties:schedule:14day:*" in patterns_scanned
+    assert "duties:schedule:14day:*" not in patterns_scanned
 
 
 def test_clear_group_unknown_group_is_noop():
@@ -406,18 +407,18 @@ def test_clear_group_scan_deletes_found_keys():
     mock_redis.scan_iter.side_effect = [
         ['user:duty:Alice:2026-01-01'],
         ['duties:today:3:0:Alice'],
-        ['duties:schedule:14day:2026-01-01'],
     ]
     fake_cache = MagicMock()
     fake_cache.cache._write_client = mock_redis
 
     clear_group("duties", cache=fake_cache)
 
-    assert mock_redis.delete.call_count == 3
+    # duties:schedule:14day:anchor is a static key deleted via cache.delete, not scan
+    fake_cache.delete.assert_called_once_with('duties:schedule:14day:anchor')
+    assert mock_redis.delete.call_count == 2
     deleted_keys = {c.args[0] for c in mock_redis.delete.call_args_list}
     assert 'user:duty:Alice:2026-01-01' in deleted_keys
     assert 'duties:today:3:0:Alice' in deleted_keys
-    assert 'duties:schedule:14day:2026-01-01' in deleted_keys
 
 
 def test_clear_group_logs_cleared_group(caplog):

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -484,6 +484,15 @@ def test_build_schedule_empty_rows_returns_all_dates_with_no_duties():
     assert all(d["duties"] == [] for d in result)
 
 
+def test_build_schedule_week_labels_relative_to_custom_anchor():
+    """Week labels are computed relative to the passed-in anchor, not the global CYCLE_ANCHOR."""
+    utils._cycle_week_for_date.cache_clear()
+    anchor = datetime(2026, 9, 1)  # deliberately not utils.CYCLE_ANCHOR
+    result = utils._build_schedule(anchor, rows=[])
+    assert [e["week"] for e in result[:7]] == ["Week A"] * 7
+    assert [e["week"] for e in result[7:]] == ["Week B"] * 7
+
+
 def test_get_current_cycle_week_calculation():
     """Verify the cycle week calculation matches the camp schedule"""
     from datetime import timedelta

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -424,7 +424,7 @@ def test_get_duty_schedule_uses_parameterized_query(mock_readonly, mock_cache):
     # Verify cache operations
     mock_cache.get.assert_called_once()
     cache_key = mock_cache.get.call_args[0][0]
-    assert cache_key.startswith('duties:schedule:14day:')
+    assert cache_key == utils.DUTY_SCHEDULE_CACHE_KEY
     mock_cache.set.assert_called_once()
     
     # Check that the query uses ANY() for parameterization instead of dynamic SQL
@@ -437,6 +437,52 @@ def test_get_duty_schedule_uses_parameterized_query(mock_readonly, mock_cache):
     # Ensure no dynamic SQL concatenation
     assert isinstance(params['days'], list)
     assert isinstance(params['cycles'], list)
+
+# ─── _build_schedule: pure function tests ────────────────────────────────────
+
+def test_build_schedule_correct_date_range():
+    """_build_schedule always produces exactly 14 entries starting from the anchor."""
+    anchor = datetime(2026, 7, 4)
+    result = utils._build_schedule(anchor, rows=[])
+    assert len(result) == 14
+    assert result[0]["date"] == "2026-07-04"
+    assert result[-1]["date"] == "2026-07-17"
+
+
+def test_build_schedule_week_labels():
+    """Each entry carries a 'Week A' or 'Week B' label."""
+    utils._cycle_week_for_date.cache_clear()
+    anchor = datetime(2026, 7, 4)
+    result = utils._build_schedule(anchor, rows=[])
+    for entry in result:
+        assert entry["week"] in ("Week A", "Week B")
+
+
+def test_build_schedule_assigns_duties_to_correct_date():
+    """Duties are placed on the right date via (day, cycle_week) matching."""
+    utils._cycle_week_for_date.cache_clear()
+    anchor = datetime(2026, 7, 4)
+    result_no_duties = utils._build_schedule(anchor, rows=[])
+    # Find Saturday Week A to get its (day, cycle_week)
+    saturday_a = next(
+        e for e in result_no_duties if e["day_name"] == "Saturday" and e["week"] == "Week A"
+    )
+    # Compute expected (day, cycle_week) for that date
+    sat_dt = datetime.strptime(saturday_a["date"], "%Y-%m-%d")
+    db_day = (sat_dt.weekday() + 1) % 7
+    cw = utils._cycle_week_for_date(sat_dt.date())
+    row = (db_day, cw, "Security", "Guard duty", "Alpha Team", [{"name": "Smith", "week": "Both"}])
+    result = utils._build_schedule(anchor, rows=[row])
+    match = next(e for e in result if e["date"] == saturday_a["date"])
+    assert match["duties"][0]["duty_name"] == "Security"
+
+
+def test_build_schedule_empty_rows_returns_all_dates_with_no_duties():
+    """No DB rows → every date entry has an empty duties list."""
+    anchor = datetime(2026, 7, 4)
+    result = utils._build_schedule(anchor, rows=[])
+    assert all(d["duties"] == [] for d in result)
+
 
 def test_get_current_cycle_week_calculation():
     """Verify the cycle week calculation matches the camp schedule"""


### PR DESCRIPTION
## Summary

- Extracts pure date arithmetic and row transformation steps from `get_duty_schedule` into `_build_schedule(start_date, rows)` so the schedule-building logic can be unit-tested without DB or Redis fixtures
- Fixes a latent cache key bug: `_duty_schedule_key()` was returning a date-stamped string (`duties:schedule:14day:2026-06-17`) that rotated daily, pointlessly invalidating a schedule whose data never changes during the fixed 14-day window. Replaced with the fixed constant `DUTY_SCHEDULE_CACHE_KEY = 'duties:schedule:14day:anchor'`
- Updates `CACHE_REGISTRY` in `cache_utils.py`: entry changes from the dynamic `duties:schedule:14day:{date}` template to the static `duties:schedule:14day:anchor` key, so `clear_group('duties')` now deletes it directly rather than via Redis SCAN

## Test plan

- [ ] 4 new pure-function tests for `_build_schedule` in `test_utils.py` — all run without any DB/Redis fixtures
- [ ] `test_cache_utils.py` updated: `duties:schedule:14day:anchor` is now confirmed as a static direct-delete key in the duties group
- [ ] `pytest backend/tests/` — 413 passed

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated 14-day duty schedule caching to use a single stable cache entry for improved consistency.
  * Refactored schedule generation to build the full 14-day response deterministically, including correct day/week labels and duty placement relative to the scheduling anchor.
* **Tests**
  * Adjusted cache-clearing and cache-lookup expectations to match the new schedule caching behavior.
  * Added unit coverage for 14-day schedule construction and week-label logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->