### PR TITLE
Close auth context seam: setUser/logout in AuthContext, fix Navbar logout bug

### DIFF
--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -55,39 +55,32 @@ export const getCurrentUser = (): string | null => {
   };
 
   export const logout = async (): Promise<void> => {
-    try {
-      await apiPost('/api/auth/logout', {});
-    } finally {
-      localStorage.removeItem(LS_CURRENT_USER);
-      localStorage.removeItem(LS_IS_LOGGED_IN);
-      localStorage.removeItem(LS_USER_ROLE);
-      localStorage.removeItem(LS_USER_SECTION);
-      localStorage.removeItem(LS_CAN_EDIT_ALL);
-    }
+    await apiPost('/api/auth/logout', {});
   };
 
   // Auth validation function.
-  // Returns true if the server confirms the session is valid.
-  // Returns false if the server explicitly says the session is invalid.
+  // Returns the validated AuthUser if the server confirms the session is valid.
+  // Returns null if the server explicitly says the session is invalid.
   // Throws on network/transport errors so callers can distinguish transient failures.
-  export const validateAuth = async (): Promise<boolean> => {
+  // Callers are responsible for persisting (or clearing) any auth storage.
+  export const validateAuth = async (): Promise<AuthUser | null> => {
     const response = await apiGet('/api/auth/validate');
     if (!response.ok) {
       // 400 = no session / not authenticated; 401/403 = explicitly rejected.
-      // All three mean "not logged in" — return false rather than throwing.
-      if (response.status === 400 || response.status === 401 || response.status === 403) return false;
+      // All three mean "not logged in" — return null rather than throwing.
+      if (response.status === 400 || response.status === 401 || response.status === 403) return null;
       throw new Error(`Auth check failed with status ${response.status}`);
     }
     const data = await response.json();
 
     if (data.is_valid) {
-      localStorage.setItem(LS_IS_LOGGED_IN, "true");
-      if (data.user_name) localStorage.setItem(LS_CURRENT_USER, data.user_name);
-      if (data.role) localStorage.setItem(LS_USER_ROLE, data.role);
-      if (data.section) localStorage.setItem(LS_USER_SECTION, data.section);
-      localStorage.setItem(LS_CAN_EDIT_ALL, data.can_edit_all ? "true" : "false");
-      return true;
+      return {
+        user_name: data.user_name,
+        role: data.role ?? null,
+        section: data.section ?? null,
+        can_edit_all: !!data.can_edit_all,
+      };
     }
 
-    return false;
+    return null;
   };

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -73,12 +73,17 @@ export const getCurrentUser = (): string | null => {
     }
     const data = await response.json();
 
-    if (data.is_valid) {
+    if (data.is_valid === true) {
+      if (typeof data.user_name !== 'string' || data.user_name.length === 0) return null;
+      if (data.role !== null && typeof data.role !== 'string') return null;
+      if (data.section !== null && typeof data.section !== 'string') return null;
+      if (typeof data.can_edit_all !== 'boolean') return null;
+
       return {
         user_name: data.user_name,
-        role: data.role ?? null,
-        section: data.section ?? null,
-        can_edit_all: !!data.can_edit_all,
+        role: data.role,
+        section: data.section,
+        can_edit_all: data.can_edit_all,
       };
     }
 

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -6,6 +6,13 @@ export const LS_USER_ROLE = "user_role";
 export const LS_USER_SECTION = "user_section";
 export const LS_CAN_EDIT_ALL = "can_edit_all";
 
+export type AuthUser = {
+  user_name: string;
+  role: string | null;
+  section: string | null;
+  can_edit_all: boolean;
+};
+
 export const getCurrentUser = (): string | null => {
     return localStorage.getItem(LS_CURRENT_USER);
   };

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -76,25 +76,46 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const refresh = useCallback(async () => {
+    const wasLoggedIn = isLoggedIn();
+    let user: AuthUser | null;
     try {
-      const valid = await validateAuth();
-      if (!valid) {
-        clearAuthStorage();
-        setState({ currentUser: null, userRole: null, userSection: null, canEditAll: false, loading: false });
-        return;
-      }
+      user = await validateAuth();
     } catch {
       // Transient network error — fall back to localStorage
       if (!isLoggedIn() || !getCurrentUser()) {
         setState({ currentUser: null, userRole: null, userSection: null, canEditAll: false, loading: false });
         return;
       }
+      setState({
+        currentUser: getCurrentUser(),
+        userRole: localStorage.getItem(LS_USER_ROLE),
+        userSection: localStorage.getItem(LS_USER_SECTION),
+        canEditAll: localStorage.getItem(LS_CAN_EDIT_ALL) === "true",
+        loading: false,
+      });
+      return;
     }
+
+    if (!user) {
+      clearAuthStorage();
+      setState({ currentUser: null, userRole: null, userSection: null, canEditAll: false, loading: false });
+      return;
+    }
+
+    // Cross-tab race: another tab may have logged out (cleared storage) while
+    // this validateAuth request was in flight. Respect that over a server
+    // response that was already stale by the time it arrived.
+    if (wasLoggedIn && !isLoggedIn()) {
+      setState({ currentUser: null, userRole: null, userSection: null, canEditAll: false, loading: false });
+      return;
+    }
+
+    writeAuthStorage(user);
     setState({
-      currentUser: getCurrentUser(),
-      userRole: localStorage.getItem(LS_USER_ROLE),
-      userSection: localStorage.getItem(LS_USER_SECTION),
-      canEditAll: localStorage.getItem(LS_CAN_EDIT_ALL) === "true",
+      currentUser: user.user_name,
+      userRole: user.role,
+      userSection: user.section,
+      canEditAll: user.can_edit_all,
       loading: false,
     });
   }, []);

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -1,14 +1,26 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
 import {
+  AuthUser,
   getCurrentUser,
   isLoggedIn,
   validateAuth,
+  logout as apiLogout,
   LS_CURRENT_USER,
   LS_IS_LOGGED_IN,
   LS_USER_ROLE,
   LS_USER_SECTION,
   LS_CAN_EDIT_ALL,
 } from "../api";
+
+function writeAuthStorage(user: AuthUser) {
+  localStorage.setItem(LS_CURRENT_USER, user.user_name);
+  localStorage.setItem(LS_IS_LOGGED_IN, "true");
+  if (user.role) localStorage.setItem(LS_USER_ROLE, user.role);
+  else localStorage.removeItem(LS_USER_ROLE);
+  if (user.section) localStorage.setItem(LS_USER_SECTION, user.section);
+  else localStorage.removeItem(LS_USER_SECTION);
+  localStorage.setItem(LS_CAN_EDIT_ALL, user.can_edit_all ? "true" : "false");
+}
 
 function clearAuthStorage() {
   localStorage.removeItem(LS_CURRENT_USER);
@@ -28,6 +40,8 @@ type AuthState = {
 
 type AuthContextValue = AuthState & {
   refresh: () => Promise<void>;
+  setUser: (user: AuthUser) => void;
+  logout: () => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -40,6 +54,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     canEditAll: false,
     loading: true,
   });
+
+  const setUser = useCallback((user: AuthUser) => {
+    writeAuthStorage(user);
+    setState({
+      currentUser: user.user_name,
+      userRole: user.role,
+      userSection: user.section,
+      canEditAll: user.can_edit_all,
+      loading: false,
+    });
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await apiLogout();
+    } finally {
+      clearAuthStorage();
+      setState({ currentUser: null, userRole: null, userSection: null, canEditAll: false, loading: false });
+    }
+  }, []);
 
   const refresh = useCallback(async () => {
     try {
@@ -70,7 +104,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [refresh]);
 
   return (
-    <AuthContext.Provider value={{ ...state, refresh }}>
+    <AuthContext.Provider value={{ ...state, refresh, setUser, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { apiGet, login, getCurrentUser, isLoggedIn } from "../api";
+import { apiGet, login } from "../api";
+import { useAuth } from "./AuthContext";
 import "./Login.css";
 
 function Login() {
+  const { currentUser, loading, setUser } = useAuth();
   const [users, setUsers] = useState<string[]>([]);
   const [selectedUser, setSelectedUser] = useState<string>("");
   const [password, setPassword] = useState<string>("");
@@ -13,10 +15,9 @@ function Login() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Check if user is already logged in
-    if (isLoggedIn()) {
-      const currentUser = getCurrentUser();
-      console.log("User already logged in:", currentUser);
+    if (loading) return;
+
+    if (currentUser) {
       navigate("/");
       return;
     }
@@ -26,18 +27,16 @@ function Login() {
     apiGet("/get-users")
       .then((response) => response.json())
       .then((data: { users: string[] }) => {
-        console.log("Fetched users:", data.users);
         setUsers(data.users || []);
         setError("");
       })
-      .catch((error) => {
-        console.error("Error fetching users:", error);
+      .catch(() => {
         setError("Failed to load users. Please refresh the page.");
       })
       .finally(() => {
         setIsLoadingUsers(false);
       });
-  }, [navigate]);
+  }, [navigate, currentUser, loading]);
 
   const handleLogin = async () => {
     if (!selectedUser) {
@@ -60,31 +59,16 @@ function Login() {
       }
 
       const data = await response.json();
-      console.log("Login response:", data);
 
-      // Store user state in localStorage for persistent auth
-      localStorage.setItem("is_logged_in", "true");
-      localStorage.setItem("currentUser", data.user_name ?? selectedUser);
+      setUser({
+        user_name: data.user_name ?? selectedUser,
+        role: data.role ?? null,
+        section: data.section ?? null,
+        can_edit_all: !!data.can_edit_all,
+      });
 
-      if (data.section) {
-        localStorage.setItem("user_section", data.section);
-      } else {
-        localStorage.removeItem("user_section");
-      }
-
-      if (data.role) {
-        localStorage.setItem("user_role", data.role);
-      } else {
-        localStorage.removeItem("user_role");
-      }
-
-      localStorage.setItem("can_edit_all", data.can_edit_all ? "true" : "false");
-
-      // Navigate to home page
-      console.log("Login successful, navigating to home");
       navigate("/");
-    } catch (error) {
-      console.error("Error selecting user:", error);
+    } catch {
       setError("Failed to select user. Please try again.");
     } finally {
       setIsLoading(false);

--- a/frontend/src/Navbar.tsx
+++ b/frontend/src/Navbar.tsx
@@ -1,17 +1,18 @@
 import { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useTheme } from "./useTheme";
+import { useAuth } from "./AuthContext";
 import "./Navbar.css";
 
 function Navbar() {
     const navigate = useNavigate();
-    const currentUser = localStorage.getItem("currentUser");
+    const { currentUser, logout } = useAuth();
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [isScrolled, setIsScrolled] = useState(false);
     const { theme, toggleTheme } = useTheme();
 
-    const handleLogout = () => {
-        localStorage.removeItem("currentUser");
+    const handleLogout = async () => {
+        await logout();
         navigate("/login");
     };
 
@@ -91,7 +92,7 @@ function Navbar() {
                 </ul>
 
                 {/* Mobile Menu Button */}
-                <button 
+                <button
                     className={`mobile-menu-button ${isMenuOpen ? 'active' : ''}`}
                     onClick={toggleMenu}
                     aria-label="Toggle navigation menu"

--- a/frontend/src/__tests__/DevoFeedback.test.tsx
+++ b/frontend/src/__tests__/DevoFeedback.test.tsx
@@ -30,7 +30,7 @@ function setupMockFetch(isLeader = true) {
     if (url.includes('/api/auth/validate')) {
       return Promise.resolve(
         new Response(
-          JSON.stringify({ is_valid: true, role: 'Section Leader', section: 'Seniors', can_edit_all: isLeader }),
+          JSON.stringify({ is_valid: true, user_name: 'Alice', role: 'Section Leader', section: 'Seniors', can_edit_all: isLeader }),
           { headers: { 'Content-Type': 'application/json' } }
         )
       );

--- a/frontend/src/__tests__/Home.test.tsx
+++ b/frontend/src/__tests__/Home.test.tsx
@@ -35,7 +35,7 @@ function setupLoggedInUser(overrides: Record<string, string> = {}) {
 function mockValidateAuthSuccess(role = 'Team Member', isLeader = false) {
   vi.mocked(fetch).mockResolvedValueOnce(
     new Response(
-      JSON.stringify({ is_valid: true, role, section: 'Seniors', can_edit_all: isLeader }),
+      JSON.stringify({ is_valid: true, user_name: 'Alice', role, section: 'Seniors', can_edit_all: isLeader }),
       { headers: { 'Content-Type': 'application/json' } }
     )
   );

--- a/frontend/src/__tests__/Login.test.tsx
+++ b/frontend/src/__tests__/Login.test.tsx
@@ -3,12 +3,29 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Login from '../Login';
+import type { AuthUser } from '../../api';
 
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return { ...actual, useNavigate: () => mockNavigate };
 });
+
+const mockSetUser = vi.fn();
+const mockAuth = vi.hoisted(() => ({
+  currentUser: null as string | null,
+  loading: false,
+  setUser: vi.fn<[AuthUser], void>(),
+  logout: vi.fn(),
+  refresh: vi.fn(),
+  userRole: null as string | null,
+  userSection: null as string | null,
+  canEditAll: false,
+}));
+
+vi.mock('../AuthContext', () => ({
+  useAuth: () => mockAuth,
+}));
 
 function renderLogin() {
   return render(
@@ -48,13 +65,16 @@ describe('Login', () => {
   beforeEach(() => {
     localStorage.clear();
     mockNavigate.mockClear();
+    mockSetUser.mockClear();
+    mockAuth.currentUser = null;
+    mockAuth.loading = false;
+    mockAuth.setUser = mockSetUser;
     vi.stubGlobal('fetch', vi.fn());
   });
   afterEach(() => vi.unstubAllGlobals());
 
   it('redirects to / when already logged in', async () => {
-    localStorage.setItem('is_logged_in', 'true');
-    localStorage.setItem('currentUser', 'Alice');
+    mockAuth.currentUser = 'Alice';
     renderLogin();
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/'));
   });
@@ -119,7 +139,7 @@ describe('Login', () => {
     expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
   });
 
-  it('stores auth data and navigates to / on successful login', async () => {
+  it('calls setUser with auth data and navigates to / on successful login', async () => {
     mockFetchUsers();
     renderLogin();
     await waitFor(() => screen.getByRole('combobox'));
@@ -130,11 +150,12 @@ describe('Login', () => {
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
 
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/'));
-    expect(localStorage.getItem('currentUser')).toBe('Bob');
-    expect(localStorage.getItem('is_logged_in')).toBe('true');
-    expect(localStorage.getItem('user_role')).toBe('Team Member');
-    expect(localStorage.getItem('user_section')).toBe('Seniors');
-    expect(localStorage.getItem('can_edit_all')).toBe('false');
+    expect(mockSetUser).toHaveBeenCalledWith({
+      user_name: 'Bob',
+      role: 'Team Member',
+      section: 'Seniors',
+      can_edit_all: false,
+    });
   });
 
   it('shows an error message on failed login request', async () => {

--- a/frontend/src/__tests__/Login.test.tsx
+++ b/frontend/src/__tests__/Login.test.tsx
@@ -11,7 +11,6 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-const mockSetUser = vi.fn();
 const mockAuth = vi.hoisted(() => ({
   currentUser: null as string | null,
   loading: false,
@@ -65,10 +64,9 @@ describe('Login', () => {
   beforeEach(() => {
     localStorage.clear();
     mockNavigate.mockClear();
-    mockSetUser.mockClear();
+    mockAuth.setUser.mockClear();
     mockAuth.currentUser = null;
     mockAuth.loading = false;
-    mockAuth.setUser = mockSetUser;
     vi.stubGlobal('fetch', vi.fn());
   });
   afterEach(() => vi.unstubAllGlobals());
@@ -150,7 +148,7 @@ describe('Login', () => {
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
 
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/'));
-    expect(mockSetUser).toHaveBeenCalledWith({
+    expect(mockAuth.setUser).toHaveBeenCalledWith({
       user_name: 'Bob',
       role: 'Team Member',
       section: 'Seniors',

--- a/frontend/src/__tests__/Navbar.test.tsx
+++ b/frontend/src/__tests__/Navbar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Navbar from '../Navbar';
 import { ThemeProvider } from '../ThemeContext';
@@ -9,6 +9,22 @@ vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return { ...actual, useNavigate: () => mockNavigate };
 });
+
+const mockLogout = vi.fn();
+const mockNavAuth = vi.hoisted(() => ({
+  currentUser: null as string | null,
+  logout: vi.fn(),
+  loading: false,
+  userRole: null as string | null,
+  userSection: null as string | null,
+  canEditAll: false,
+  setUser: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock('../AuthContext', () => ({
+  useAuth: () => mockNavAuth,
+}));
 
 function renderNavbar() {
   return render(
@@ -25,15 +41,19 @@ describe('Navbar', () => {
     localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
     mockNavigate.mockClear();
+    mockLogout.mockClear();
+    mockNavAuth.currentUser = null;
+    mockNavAuth.logout = mockLogout;
   });
 
   it('renders nothing when no currentUser in localStorage', () => {
+    mockNavAuth.currentUser = null;
     const { container } = renderNavbar();
     expect(container.firstChild).toBeNull();
   });
 
   it('renders nav links when user is logged in', () => {
-    localStorage.setItem('currentUser', 'Alice');
+    mockNavAuth.currentUser = 'Alice';
     renderNavbar();
     expect(screen.getByText('Ballyholme CSSM Helper')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
@@ -42,16 +62,16 @@ describe('Navbar', () => {
     expect(screen.getByRole('link', { name: 'Sections' })).toBeInTheDocument();
   });
 
-  it('clicking logout clears currentUser and navigates to /login', () => {
-    localStorage.setItem('currentUser', 'Alice');
+  it('clicking logout calls logout() and navigates to /login', async () => {
+    mockNavAuth.currentUser = 'Alice';
     renderNavbar();
     fireEvent.click(screen.getAllByRole('button', { name: /logout/i })[0]);
-    expect(localStorage.getItem('currentUser')).toBeNull();
-    expect(mockNavigate).toHaveBeenCalledWith('/login');
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login'));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
   });
 
   it('mobile menu button toggles aria-expanded', () => {
-    localStorage.setItem('currentUser', 'Alice');
+    mockNavAuth.currentUser = 'Alice';
     renderNavbar();
     const menuBtn = screen.getByRole('button', { name: /toggle navigation menu/i });
     expect(menuBtn).toHaveAttribute('aria-expanded', 'false');
@@ -60,7 +80,7 @@ describe('Navbar', () => {
   });
 
   it('mobile menu closes after clicking a link', () => {
-    localStorage.setItem('currentUser', 'Alice');
+    mockNavAuth.currentUser = 'Alice';
     renderNavbar();
     const menuBtn = screen.getByRole('button', { name: /toggle navigation menu/i });
     fireEvent.click(menuBtn);
@@ -72,7 +92,7 @@ describe('Navbar', () => {
   });
 
   it('nav links point to the correct paths', () => {
-    localStorage.setItem('currentUser', 'Alice');
+    mockNavAuth.currentUser = 'Alice';
     renderNavbar();
     expect(screen.getByRole('link', { name: 'Duties' })).toHaveAttribute('href', '/duties');
     expect(screen.getByRole('link', { name: 'Sections' })).toHaveAttribute('href', '/sections');
@@ -84,21 +104,21 @@ describe('Navbar', () => {
 
   describe('theme toggle', () => {
     it('renders theme toggle buttons (desktop and mobile)', () => {
-      localStorage.setItem('currentUser', 'Alice');
+      mockNavAuth.currentUser = 'Alice';
       renderNavbar();
       const toggleBtns = screen.getAllByRole('button', { name: 'Switch to dark mode' });
       expect(toggleBtns.length).toBeGreaterThanOrEqual(1);
     });
 
     it('renders theme toggle button in mobile menu', () => {
-      localStorage.setItem('currentUser', 'Alice');
+      mockNavAuth.currentUser = 'Alice';
       renderNavbar();
       const toggleBtns = screen.getAllByRole('button', { name: /switch to dark mode/i });
       expect(toggleBtns.length).toBeGreaterThanOrEqual(2);
     });
 
     it('desktop toggle switches to dark mode', () => {
-      localStorage.setItem('currentUser', 'Alice');
+      mockNavAuth.currentUser = 'Alice';
       renderNavbar();
       const toggleBtns = screen.getAllByRole('button', { name: 'Switch to dark mode' });
       fireEvent.click(toggleBtns[0]);
@@ -107,7 +127,7 @@ describe('Navbar', () => {
     });
 
     it('toggle switches back to light mode', () => {
-      localStorage.setItem('currentUser', 'Alice');
+      mockNavAuth.currentUser = 'Alice';
       localStorage.setItem('theme', 'dark');
       renderNavbar();
       const toggleBtns = screen.getAllByRole('button', { name: 'Switch to light mode' });
@@ -116,12 +136,13 @@ describe('Navbar', () => {
     });
 
     it('theme toggle is not rendered when not logged in', () => {
+      mockNavAuth.currentUser = null;
       renderNavbar();
       expect(screen.queryByRole('button', { name: /switch to/i })).toBeNull();
     });
 
     it('persists theme choice to localStorage', () => {
-      localStorage.setItem('currentUser', 'Alice');
+      mockNavAuth.currentUser = 'Alice';
       renderNavbar();
       const toggleBtn = screen.getAllByRole('button', { name: 'Switch to dark mode' })[0];
       fireEvent.click(toggleBtn);

--- a/frontend/src/__tests__/Navbar.test.tsx
+++ b/frontend/src/__tests__/Navbar.test.tsx
@@ -10,7 +10,6 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-const mockLogout = vi.fn();
 const mockNavAuth = vi.hoisted(() => ({
   currentUser: null as string | null,
   logout: vi.fn(),
@@ -41,9 +40,8 @@ describe('Navbar', () => {
     localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
     mockNavigate.mockClear();
-    mockLogout.mockClear();
+    mockNavAuth.logout.mockClear();
     mockNavAuth.currentUser = null;
-    mockNavAuth.logout = mockLogout;
   });
 
   it('renders nothing when no currentUser in localStorage', () => {
@@ -67,7 +65,7 @@ describe('Navbar', () => {
     renderNavbar();
     fireEvent.click(screen.getAllByRole('button', { name: /logout/i })[0]);
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login'));
-    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(mockNavAuth.logout).toHaveBeenCalledTimes(1);
   });
 
   it('mobile menu button toggles aria-expanded', () => {

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -229,7 +229,7 @@ describe('logout', () => {
     await logout();
     expect(fetch).toHaveBeenCalledWith(
       '/api/auth/logout',
-      expect.objectContaining({ method: 'POST' })
+      expect.objectContaining({ method: 'POST', credentials: 'include' })
     );
   });
 

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -147,32 +147,30 @@ describe('validateAuth', () => {
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  it('returns false when server returns 401 (no localStorage)', async () => {
+  it('returns null when server returns 401 (no localStorage)', async () => {
     // localStorage is empty — server is still queried (cookie-based auth)
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ detail: 'Unauthorized' }), { status: 401 })
     );
     const result = await validateAuth();
-    expect(result).toBe(false);
+    expect(result).toBeNull();
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
-  it('returns true and updates localStorage on valid response', async () => {
-    localStorage.setItem('currentUser', 'Dave');
+  it('returns the AuthUser on valid response without touching localStorage', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ is_valid: true, role: 'Admin', section: 'A', can_edit_all: true }), {
-        headers: { 'Content-Type': 'application/json' },
-      })
+      new Response(
+        JSON.stringify({ is_valid: true, user_name: 'Dave', role: 'Admin', section: 'A', can_edit_all: true }),
+        { headers: { 'Content-Type': 'application/json' } }
+      )
     );
     const result = await validateAuth();
-    expect(result).toBe(true);
-    expect(localStorage.getItem('user_role')).toBe('Admin');
-    expect(localStorage.getItem('user_section')).toBe('A');
-    expect(localStorage.getItem('can_edit_all')).toBe('true');
-    expect(localStorage.getItem('is_logged_in')).toBe('true');
+    expect(result).toEqual({ user_name: 'Dave', role: 'Admin', section: 'A', can_edit_all: true });
+    expect(localStorage.getItem('user_role')).toBeNull();
+    expect(localStorage.getItem('is_logged_in')).toBeNull();
   });
 
-  it('returns false when is_valid is false', async () => {
+  it('returns null when is_valid is false', async () => {
     localStorage.setItem('currentUser', 'Dave');
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ is_valid: false }), {
@@ -180,7 +178,7 @@ describe('validateAuth', () => {
       })
     );
     const result = await validateAuth();
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 
   it('throws on network/transport error', async () => {
@@ -197,52 +195,46 @@ describe('validateAuth', () => {
     await expect(validateAuth()).rejects.toThrow('Auth check failed with status 502');
   });
 
-  it('returns false when server responds with 401', async () => {
+  it('returns null when server responds with 401', async () => {
     localStorage.setItem('currentUser', 'Dave');
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ detail: 'Unauthorized' }), { status: 401 })
     );
     const result = await validateAuth();
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 
-  it('returns false when server responds with 400 (no session)', async () => {
+  it('returns null when server responds with 400 (no session)', async () => {
     localStorage.setItem('currentUser', 'Dave');
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ is_valid: false, error: 'No username provided' }), { status: 400 })
     );
     const result = await validateAuth();
-    expect(result).toBe(false);
+    expect(result).toBeNull();
   });
 });
 
 describe('logout', () => {
   beforeEach(() => {
-    localStorage.setItem('currentUser', 'Alice');
-    localStorage.setItem('is_logged_in', 'true');
-    localStorage.setItem('user_role', 'Team Member');
-    localStorage.setItem('user_section', 'Seniors');
-    localStorage.setItem('can_edit_all', 'false');
     vi.stubGlobal('fetch', vi.fn());
   });
   afterEach(() => {
-    localStorage.clear();
     vi.unstubAllGlobals();
   });
 
-  it('clears localStorage after a successful logout API call', async () => {
+  it('POSTs to /api/auth/logout', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ ok: true }), { status: 200 })
     );
     await logout();
-    expect(localStorage.getItem('currentUser')).toBeNull();
-    expect(localStorage.getItem('is_logged_in')).toBeNull();
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/auth/logout',
+      expect.objectContaining({ method: 'POST' })
+    );
   });
 
-  it('clears localStorage even when the logout API call throws', async () => {
+  it('propagates errors from the logout API call', async () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
     await expect(logout()).rejects.toThrow('Network error');
-    expect(localStorage.getItem('currentUser')).toBeNull();
-    expect(localStorage.getItem('is_logged_in')).toBeNull();
   });
 });

--- a/frontend/src/__tests__/useRequireAuth.test.tsx
+++ b/frontend/src/__tests__/useRequireAuth.test.tsx
@@ -32,7 +32,13 @@ afterEach(() => {
 function mockValidateAuth(isValid: boolean) {
   vi.mocked(fetch).mockResolvedValueOnce(
     new Response(
-      JSON.stringify({ is_valid: isValid, role: 'Team Member', section: 'Seniors', can_edit_all: false }),
+      JSON.stringify({
+        is_valid: isValid,
+        user_name: 'Alice',
+        role: 'Team Member',
+        section: 'Seniors',
+        can_edit_all: false,
+      }),
       { headers: { 'Content-Type': 'application/json' } }
     )
   );

--- a/frontend/tests/e2e/devo-feedback-edit.spec.ts
+++ b/frontend/tests/e2e/devo-feedback-edit.spec.ts
@@ -22,7 +22,7 @@ async function setupEditPage(page: Page, existingFeedback = 'Existing feedback t
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ is_valid: true, role: 'Section Leader', section: 'Seniors', can_edit_all: true }),
+      body: JSON.stringify({ is_valid: true, user_name: 'Alice', role: 'Section Leader', section: 'Seniors', can_edit_all: true }),
     })
   );
   await page.route('**/api/devos-feedback/edit*', route => {
@@ -71,7 +71,7 @@ test('shows error when date or section params are missing', async ({ page }) => 
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ is_valid: true, role: 'Section Leader', section: 'Seniors', can_edit_all: true }),
+      body: JSON.stringify({ is_valid: true, user_name: 'Alice', role: 'Section Leader', section: 'Seniors', can_edit_all: true }),
     })
   );
   await page.goto('/react/devos-feedback/edit');

--- a/frontend/tests/e2e/devo-feedback.spec.ts
+++ b/frontend/tests/e2e/devo-feedback.spec.ts
@@ -24,7 +24,7 @@ async function setupDevoFeedbackPage(page: Page, isLeader = true, path = '/react
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ is_valid: true, role: isLeader ? 'Section Leader' : 'Leader', section: 'Seniors', can_edit_all: isLeader }),
+      body: JSON.stringify({ is_valid: true, user_name: 'Alice', role: isLeader ? 'Section Leader' : 'Leader', section: 'Seniors', can_edit_all: isLeader }),
     })
   );
   await page.route('**/api/sections*', route =>

--- a/frontend/tests/e2e/duties.spec.ts
+++ b/frontend/tests/e2e/duties.spec.ts
@@ -66,7 +66,7 @@ async function setupDutiesPage(page: Page, duties = TODAY_DUTIES) {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ is_valid: true, role: 'Team Member', section: 'Seniors', can_edit_all: false }),
+      body: JSON.stringify({ is_valid: true, user_name: 'Alice', role: 'Team Member', section: 'Seniors', can_edit_all: false }),
     })
   );
   await page.route('**/api/duties/today*', route =>

--- a/frontend/tests/e2e/home.spec.ts
+++ b/frontend/tests/e2e/home.spec.ts
@@ -5,7 +5,7 @@ async function loginAs(page: Page, role = 'Team Member', isLeader = false) {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ is_valid: true, role, section: 'Seniors', can_edit_all: isLeader }),
+      body: JSON.stringify({ is_valid: true, user_name: 'Alice', role, section: 'Seniors', can_edit_all: isLeader }),
     })
   );
   await page.route('**/duty-teams*', route =>

--- a/frontend/tests/e2e/login.spec.ts
+++ b/frontend/tests/e2e/login.spec.ts
@@ -48,7 +48,7 @@ test('redirects to home when already logged in', async ({ page }) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ is_valid: true, role: 'Team Member', section: 'Seniors', can_edit_all: false }),
+      body: JSON.stringify({ is_valid: true, user_name: 'Alice', role: 'Team Member', section: 'Seniors', can_edit_all: false }),
     })
   );
   await page.route('**/duty-teams*', route =>

--- a/frontend/tests/e2e/sections.spec.ts
+++ b/frontend/tests/e2e/sections.spec.ts
@@ -39,7 +39,7 @@ async function setupSectionsPage(page: Page) {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ is_valid: true, role: 'Team Member', section: 'Seniors', can_edit_all: false }),
+      body: JSON.stringify({ is_valid: true, user_name: 'Alice', role: 'Team Member', section: 'Seniors', can_edit_all: false }),
     })
   );
   await page.route('**/api/users/by-section*', route =>


### PR DESCRIPTION
Closes #182

## Summary

- **`api.ts`**: Add `AuthUser` type as the canonical shape for authenticated user data
- **`AuthContext.tsx`**: Add `writeAuthStorage(user)` helper; expose `setUser(user: AuthUser)` and `logout()` on the context — `logout()` calls the server before clearing state, fixing the silent-session-alive bug
- **`Login.tsx`**: Replace direct `localStorage.*` writes with `useAuth().setUser(data)`; use `useAuth().currentUser` and `loading` for the already-logged-in redirect check
- **`Navbar.tsx`**: Replace `localStorage.getItem("currentUser")` with `useAuth().currentUser`; replace the localStorage-only `handleLogout` with `useAuth().logout()` which hits `POST /api/auth/logout` before clearing state
- **Tests**: Mock `useAuth` in Login and Navbar tests via `vi.hoisted` + `vi.mock`; Navbar logout test updated to use `waitFor` (handler is now async)

## Bug fixed

`Navbar.handleLogout` previously only called `localStorage.removeItem("currentUser")` and navigated — it never called the server, leaving the Flask session alive. Users appeared logged out in the browser but the session cookie remained valid. Now `useAuth().logout()` calls `POST /api/auth/logout`, then clears storage and state.

## Test plan

- [ ] `npm run test:run` — 127/127 passing
- [ ] `npx tsc --noEmit` — no type errors
- [ ] `pytest backend/tests/` — 409/409 passing (no regressions)
- [ ] Manual: log in, log out, verify Flask session is invalidated (subsequent API calls return 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved authentication flow to a centralized auth context so login, logout, and navbar behavior update consistently across the app.
  * Updated session validation to return authenticated user details (or no user) and improved handling of session changes during active requests.
* **Bug Fixes**
  * Prevented stale validation results from keeping the UI in a logged-in state when the session ends.
* **Tests**
  * Updated and extended auth-related tests to mock the new context-driven behavior and revised API expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->