### PR TITLE
Default new devos feedback entries to a Praise/Prayer template

### DIFF
--- a/backend/bcssm_backend/feedback_queries.py
+++ b/backend/bcssm_backend/feedback_queries.py
@@ -26,7 +26,7 @@ def get_feedback_by_date(date_str):
     LEFT JOIN feedback f ON s.id = f.section_id AND f.date = :date;
     """
     feedback_rows = _db.execute_readonly_query(query, {"date": date_str})
-    return {row[0]: row[1] if row[1] is not None else "No feedback available" for row in feedback_rows}
+    return {row[0]: row[1] for row in feedback_rows}
 
 
 def save_devos_feedback(section_name: str, date_str: str, new_feedback: str, editor_id: int) -> None:

--- a/backend/tests/test_devos_feedback.py
+++ b/backend/tests/test_devos_feedback.py
@@ -44,7 +44,7 @@ def test_get_feedback_by_date_success(mock_read):
     result = get_feedback_by_date("2025-06-07")
     assert result == {
         "Minis": "Great job",
-        "Majors": "No feedback available"
+        "Majors": None
     }
 
 def test_get_feedback_by_date_exception(mock_read):

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -917,7 +917,7 @@ def test_get_feedback_by_date_success(monkeypatch):
     mock_exec = MagicMock(return_value=[("Minis", "Great job"), ("Majors", None)])
     monkeypatch.setattr("backend.bcssm_backend.db_utils.execute_readonly_query", mock_exec)
     result = feedback_queries.get_feedback_by_date("2025-06-07")
-    assert result == {"Minis": "Great job", "Majors": "No feedback available"}
+    assert result == {"Minis": "Great job", "Majors": None}
 
 
 def test_get_feedback_by_date_exception(monkeypatch):

--- a/frontend/src/DevoFeedbackEdit.tsx
+++ b/frontend/src/DevoFeedbackEdit.tsx
@@ -7,6 +7,8 @@ import { useAuth } from './AuthContext';
 import { useApiGet } from './hooks/useApiGet';
 import "./DevoFeedbackEdit.css";
 
+const DEFAULT_FEEDBACK_TEMPLATE = 'Praise: \nPrayer: \n';
+
 const DevoFeedbackEdit: React.FC = () => {
   const [searchParams] = useSearchParams();
   const dateStr = searchParams.get('date') || '';
@@ -25,7 +27,10 @@ const DevoFeedbackEdit: React.FC = () => {
     `/api/devos-feedback?date=${encodeURIComponent(dateStr)}&section=${encodeURIComponent(section)}`,
     {
       skip: !currentUser || missingParams,
-      transform: (raw) => (raw as { feedback?: Record<string, string> }).feedback?.[section] ?? '',
+      transform: (raw) => {
+        const value = (raw as { feedback?: Record<string, string | null> }).feedback?.[section];
+        return value && value.trim() ? value : DEFAULT_FEEDBACK_TEMPLATE;
+      },
     }
   );
 


### PR DESCRIPTION
## Summary
- Editing a devos feedback entry for the first time previously prefilled the textarea with the literal string "No feedback available" (a backend placeholder), so leaders had to delete it before typing.
- `get_feedback_by_date` now returns `null` for sections with no feedback for the given date instead of the `"No feedback available"` placeholder string.
- The edit page (`DevoFeedbackEdit.tsx`) now defaults empty/missing feedback to a `Praise: \nPrayer: \n` template, giving leaders a starting structure to fill in.
- Updated the two backend unit tests that asserted the old placeholder string.

## Test plan
- [x] `pytest backend/tests/` — 411 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 127 passed
- [x] `npx playwright test` — 194 passed, 10 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default “Praise” and “Prayer” text when creating or editing feedback without existing content.

* **Bug Fixes**
  * Feedback entries without submitted content now remain clearly identifiable as empty rather than displaying a placeholder message.
  * Existing feedback is trimmed before display, while blank entries use the default template.

* **Tests**
  * Updated coverage to reflect the revised handling of missing feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->